### PR TITLE
Add units and descriptions to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,30 +1,56 @@
 evader:
+  # Mass of the evader aircraft [kg]
   mass: 500.0
+  # Maximum acceleration magnitude the evader can command [m/s^2]
   max_acceleration: 20.0
+  # Upper speed limit [m/s]
   top_speed: 300.0
+  # Dimensionless coefficient modelling drag
   drag_coefficient: 0.02
+  # How much information the evader gets about the pursuer
   awareness_mode: 1
+  # Maximum rotation rate of the thrust vector [rad/s]
   turn_rate: 3.141592653589793
+  # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
+  # Maximum allowable pitch angle [rad]
   stall_angle: 1.0471975511965976
 pursuer:
+  # Mass of the pursuer [kg]
   mass: 1000.0
+  # Maximum acceleration magnitude [m/s^2]
   max_acceleration: 30.0
+  # Upper speed limit [m/s]
   top_speed: 350.0
+  # Dimensionless coefficient modelling drag
   drag_coefficient: 0.03
+  # Maximum rotation rate of the thrust vector [rad/s]
   turn_rate: 4.71238898038469
+  # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
+  # Maximum allowable pitch angle [rad]
   stall_angle: 1.3089969389957472
+# Downward gravitational acceleration [m/s^2]
 gravity: 9.81
+# Simulation time step [s]
 time_step: 0.1
+# Distance at which capture is considered successful [m]
 capture_radius: 1.0
+# Weight for shaping rewards
 shaping_weight: 0.05
+# Coordinates of the evader's goal [m]
 target_position: [1000.0, 0.0, 0.0]
 pursuer_start:
+  # Maximum half angle of the pursuer spawn cone [rad]
   cone_half_angle: 0.7853981633974483
+  # Minimum initial range from the evader [m]
   min_range: 1000.0
+  # Maximum initial range from the evader [m]
   max_range: 5000.0
+  # Radius around the evader target where the pursuer aims initially [m]
   force_target_radius: 500.0
+  # Range of random initial speeds [m/s]
   initial_speed_range: [0.0, 50.0]
 initial_positions:
+  # Starting position of the evader [m]
   evader: [0.0, 0.0, 3000.0]


### PR DESCRIPTION
## Summary
- document physical units and each parameter meaning directly in `config.yaml`

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py`

------
https://chatgpt.com/codex/tasks/task_e_686be6839ed48332a891e741587bd4c6