### PR TITLE
Add PPO training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ The defaults for these options live in ``pursuit_evasion.py`` under
 It will print evaluation statistics every ``--eval-freq`` episodes and a final
 summary when training finishes.
 
+### PPO variant
+
+For a more stable actor--critic approach, run the ``train_pursuer_ppo.py``
+script which implements a minimal Proximal Policy Optimization loop with an
+entropy bonus:
+
+```bash
+python train_pursuer_ppo.py
+```
+
+The command line options are the same as for ``train_pursuer.py``.
+
 ## Additional scripts
 
 - `pursuit_evasion.py` contains the environment implementation along with a


### PR DESCRIPTION
## Summary
- add `train_pursuer_ppo.py` implementing a minimal PPO loop with entropy bonus
- document the PPO script in README

## Testing
- `python -m py_compile train_pursuer_ppo.py train_pursuer.py pursuit_evasion.py`
- `python train_pursuer_ppo.py --episodes 1 --eval-freq 1` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686be9de2770833284223b6ee03c72a0