### PR TITLE
Enable GPU support and yaw/pitch rates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,8 +9,10 @@ evader:
   drag_coefficient: 0.02
   # How much information the evader gets about the pursuer
   awareness_mode: 1
-  # Maximum rotation rate of the thrust vector [rad/s]
-  turn_rate: 3.141592653589793
+  # Maximum yaw rotation rate [rad/s]
+  yaw_rate: 3.141592653589793
+  # Maximum pitch rotation rate [rad/s]
+  pitch_rate: 3.141592653589793
   # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
   # Maximum allowable pitch angle [rad]
@@ -24,8 +26,10 @@ pursuer:
   top_speed: 350.0
   # Dimensionless coefficient modelling drag
   drag_coefficient: 0.03
-  # Maximum rotation rate of the thrust vector [rad/s]
-  turn_rate: 4.71238898038469
+  # Maximum yaw rotation rate [rad/s]
+  yaw_rate: 4.71238898038469
+  # Maximum pitch rotation rate [rad/s]
+  pitch_rate: 4.71238898038469
   # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
   # Maximum allowable pitch angle [rad]

--- a/notebooks/training_demo.ipynb
+++ b/notebooks/training_demo.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pursuer training demo\n",
+    "This notebook demonstrates how to train the pursuer step by step using the provided environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import torch\n",
+    "from pursuit_evasion import PursuitEvasionEnv, PursuerPolicy, load_config\n",
+    "from train_pursuer import PursuerOnlyEnv, evaluate\n",
+    "\n",
+    "config = load_config()\n",
+    "config['evader']['awareness_mode'] = 1\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "env = PursuerOnlyEnv(config)\n",
+    "policy = PursuerPolicy(env.observation_space.shape[0]).to(device)\n",
+    "optimizer = torch.optim.Adam(policy.parameters(), lr=1e-3)\n",
+    "gamma = 0.99\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "for episode in range(50):\n",
+    "    obs, _ = env.reset()\n",
+    "    log_probs = []\n",
+    "    rewards = []\n",
+    "    done = False\n",
+    "    while not done:\n",
+    "        obs_t = torch.tensor(obs, dtype=torch.float32, device=device)\n",
+    "        mean = policy(obs_t)\n",
+    "        dist = torch.distributions.Normal(mean, torch.ones_like(mean))\n",
+    "        action = dist.sample()\n",
+    "        log_prob = dist.log_prob(action).sum()\n",
+    "        obs, r, done, _, _ = env.step(action.cpu().numpy())\n",
+    "        log_probs.append(log_prob)\n",
+    "        rewards.append(r)\n",
+    "    returns = []\n",
+    "    G = 0.0\n",
+    "    for r in reversed(rewards):\n",
+    "        G = r + gamma * G\n",
+    "        returns.insert(0, G)\n",
+    "    returns = torch.tensor(returns, dtype=torch.float32, device=device)\n",
+    "    returns = (returns - returns.mean()) / (returns.std() + 1e-8)\n",
+    "    loss = -torch.sum(torch.stack(log_probs) * returns)\n",
+    "    optimizer.zero_grad()\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "print('Training done')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "avg_r, success = evaluate(policy, PursuerOnlyEnv(config))\n",
+    "print(f'Average reward: {avg_r:.2f}, success rate: {success:.2f}')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- support separate yaw/pitch turn rates in `PursuitEvasionEnv`
- update config file with yaw/pitch rates
- add GPU device handling to training scripts
- allow overriding `time_step` via CLI
- provide a step-by-step training notebook

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py notebooks/training_demo.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_686d72ab2a8083329da543a8c512c4f0