### PR TITLE
Enable policy saving and add playback script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ pursuer while the evader follows a scripted behaviour. To start training run:
 ```bash
 python train_pursuer.py
 ```
+The script saves the trained policy to `pursuer_policy.pt` by default. You can
+override this with `--save-path`.
 
 The script accepts a few command line options to control the training. For
 instance, to run 200 episodes with a smaller learning rate and evaluation every
@@ -55,8 +57,9 @@ entropy bonus:
 ```bash
 python train_pursuer_ppo.py
 ```
-
-The command line options are the same as for ``train_pursuer.py``.
+The command line options are the same as for ``train_pursuer.py`` and the
+trained weights are written to ``pursuer_ppo.pt`` unless ``--save-path`` is
+specified.
 
 ## Additional scripts
 
@@ -68,6 +71,9 @@ python pursuit_evasion.py
 ```
 
 which is useful for quickly checking that the environment works.
+
+- `play.py` loads a saved policy and runs a single episode. Use the `--ppo`
+  flag when loading a model trained with the PPO script.
 
 ## Adjusting environment parameters
 

--- a/play.py
+++ b/play.py
@@ -1,0 +1,54 @@
+import argparse
+import torch
+
+from pursuit_evasion import PursuerPolicy, load_config
+from train_pursuer import PursuerOnlyEnv
+from train_pursuer_ppo import ActorCritic
+
+
+def run_episode(model_path: str, use_ppo: bool = False) -> None:
+    cfg = load_config()
+    cfg['evader']['awareness_mode'] = 1
+    env = PursuerOnlyEnv(cfg)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    if use_ppo:
+        model = ActorCritic(env.observation_space.shape[0])
+    else:
+        model = PursuerPolicy(env.observation_space.shape[0])
+    state = torch.load(model_path, map_location=device)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
+
+    obs, _ = env.reset()
+    done = False
+    total_reward = 0.0
+    while not done:
+        with torch.no_grad():
+            obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
+            if use_ppo:
+                mean, _ = model(obs_t)
+            else:
+                mean = model(obs_t)
+            dist = torch.distributions.Normal(mean, torch.ones_like(mean))
+            action = dist.mean
+        obs, r, done, _, _ = env.step(action.cpu().numpy())
+        total_reward += r
+
+    print(f"Episode reward: {total_reward:.2f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run a single episode using a saved pursuer model"
+    )
+    parser.add_argument(
+        "--model", type=str, default="pursuer_policy.pt", help="path to weight file"
+    )
+    parser.add_argument(
+        "--ppo", action="store_true", help="load weights from PPO training"
+    )
+    args = parser.parse_args()
+
+    run_episode(args.model, use_ppo=args.ppo)

--- a/train_pursuer.py
+++ b/train_pursuer.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import gymnasium as gym
+from typing import Optional
 
 from pursuit_evasion import PursuitEvasionEnv, PursuerPolicy, load_config
 
@@ -83,7 +84,7 @@ def evaluate(policy: PursuerPolicy, env: PursuerOnlyEnv, episodes: int = 5) -> t
     return float(np.mean(rewards)), successes / episodes
 
 
-def train(cfg: dict):
+def train(cfg: dict, save_path: Optional[str] = None):
     """Train the pursuer policy with REINFORCE.
 
     Parameters
@@ -140,6 +141,10 @@ def train(cfg: dict):
     avg_r, success = evaluate(policy, PursuerOnlyEnv(config))
     print(f"Final performance: avg_reward={avg_r:.2f} success={success:.2f}")
 
+    if save_path is not None:
+        torch.save(policy.state_dict(), save_path)
+        print(f"Model saved to {save_path}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train the pursuer policy")
@@ -151,6 +156,9 @@ if __name__ == "__main__":
                         help="how often to run evaluation episodes")
     parser.add_argument("--time-step", type=float,
                         help="simulation time step override")
+    parser.add_argument("--save-path", type=str,
+                        default="pursuer_policy.pt",
+                        help="where to store the trained weights")
     args = parser.parse_args()
 
     training_cfg = config.setdefault('training', {
@@ -167,4 +175,4 @@ if __name__ == "__main__":
     if args.time_step is not None:
         config['time_step'] = args.time_step
 
-    train(config)
+    train(config, save_path=args.save_path)

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import gymnasium as gym
+from typing import Optional
 
 from pursuit_evasion import (
     PursuitEvasionEnv,
@@ -94,7 +95,7 @@ def evaluate(model: ActorCritic, env: PursuerOnlyEnv, episodes: int = 5):
     return float(np.mean(rewards)), successes / episodes
 
 
-def train(cfg: dict):
+def train(cfg: dict, save_path: Optional[str] = None):
     training_cfg = cfg.get('training', {})
     num_episodes = training_cfg.get('episodes', 100)
     learning_rate = training_cfg.get('learning_rate', 1e-3)
@@ -171,6 +172,10 @@ def train(cfg: dict):
     avg_r, success = evaluate(model, PursuerOnlyEnv(cfg))
     print(f"Final performance: avg_reward={avg_r:.2f} success={success:.2f}")
 
+    if save_path is not None:
+        torch.save(model.state_dict(), save_path)
+        print(f"Model saved to {save_path}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train the pursuer policy using PPO")
@@ -178,6 +183,8 @@ if __name__ == "__main__":
     parser.add_argument("--lr", type=float, help="optimizer learning rate")
     parser.add_argument("--eval-freq", type=int, help="how often to run evaluation")
     parser.add_argument("--time-step", type=float, help="simulation time step override")
+    parser.add_argument("--save-path", type=str, default="pursuer_ppo.pt",
+                        help="where to store the trained weights")
     args = parser.parse_args()
 
     training_cfg = config.setdefault(
@@ -192,4 +199,4 @@ if __name__ == "__main__":
     if args.time_step is not None:
         config['time_step'] = args.time_step
 
-    train(config)
+    train(config, save_path=args.save_path)


### PR DESCRIPTION
## Summary
- allow saving model weights when training
- document new `--save-path` option for both trainers
- add `play.py` to run a saved policy

## Testing
- `python -m py_compile train_pursuer.py train_pursuer_ppo.py play.py pursuit_evasion.py`

------
https://chatgpt.com/codex/tasks/task_e_686d75c4c70483328f0befc245c3afc2