### PR TITLE
Add trajectory plotting to play script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 torch
 gymnasium
+matplotlib


### PR DESCRIPTION
## Summary
- record pursuer and evader positions when running an episode
- show a 3D plot of both trajectories at the end
- include matplotlib in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9a06100c8332a9266bf69b722b3d