### PR TITLE
Document awareness mode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,14 @@ values such as masses, maximum acceleration or the starting distance of
 the pursuer.  Both `pursuit_evasion.py` and `train_pursuer.py` load the
 configuration at runtime, so changes take effect the next time you run
 the scripts.
+
+The `evader.awareness_mode` option defines how much information the
+evader receives about the pursuer:
+
+1. `1` – no knowledge of the pursuer
+2. `2` – only the distance to the pursuer
+3. `3` – the unit vector pointing to the pursuer
+4. `4` – full pursuer position (values above 4 behave the same)
+
+The `yaw_rate` and `pitch_rate` values for both agents are specified in
+degrees per second and are converted internally to radians per second.

--- a/config.yaml
+++ b/config.yaml
@@ -8,11 +8,15 @@ evader:
   # Dimensionless coefficient modelling drag
   drag_coefficient: 0.02
   # How much information the evader gets about the pursuer
+  #   1 - evader has no knowledge of the pursuer
+  #   2 - only the distance to the pursuer is observed
+  #   3 - evader receives the unit vector pointing to the pursuer
+  #   4 - full pursuer position is known (values >4 behave the same)
   awareness_mode: 1
-  # Maximum yaw rotation rate [rad/s]
-  yaw_rate: 3.141592653589793
-  # Maximum pitch rotation rate [rad/s]
-  pitch_rate: 3.141592653589793
+  # Maximum yaw rotation rate [deg/s]
+  yaw_rate: 180.0
+  # Maximum pitch rotation rate [deg/s]
+  pitch_rate: 180.0
   # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
   # Maximum allowable pitch angle [rad]
@@ -26,10 +30,10 @@ pursuer:
   top_speed: 350.0
   # Dimensionless coefficient modelling drag
   drag_coefficient: 0.03
-  # Maximum yaw rotation rate [rad/s]
-  yaw_rate: 4.71238898038469
-  # Maximum pitch rotation rate [rad/s]
-  pitch_rate: 4.71238898038469
+  # Maximum yaw rotation rate [deg/s]
+  yaw_rate: 270.0
+  # Maximum pitch rotation rate [deg/s]
+  pitch_rate: 270.0
   # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
   # Maximum allowable pitch angle [rad]

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -182,8 +182,8 @@ class PursuitEvasionEnv(gym.Env):
         max_acc = cfg_a['max_acceleration']
         top_speed = cfg_a['top_speed']
         drag_c = cfg_a['drag_coefficient']
-        yaw_rate = cfg_a.get('yaw_rate', cfg_a.get('turn_rate', 0.0))
-        pitch_rate = cfg_a.get('pitch_rate', cfg_a.get('turn_rate', 0.0))
+        yaw_rate = np.deg2rad(cfg_a.get('yaw_rate', cfg_a.get('turn_rate', 0.0)))
+        pitch_rate = np.deg2rad(cfg_a.get('pitch_rate', cfg_a.get('turn_rate', 0.0)))
         stall = cfg_a['stall_angle']
         if name == 'evader':
             pos = self.evader_pos


### PR DESCRIPTION
## Summary
- document awareness mode choices in `config.yaml`
- add explanation of awareness modes in README
- specify yaw/pitch rate in degrees
- convert turn rate config to radians in code

## Testing
- `pip install -r requirements.txt` *(fails: ModuleNotFoundError)*
- `pip install pyyaml`
- `python pursuit_evasion.py` *(fails: No module named 'gymnasium')*

------
https://chatgpt.com/codex/tasks/task_e_686e2c1c32f08332900a6bd03d5fd470