### PR TITLE
Update stall angle to use degrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,5 @@ evader receives about the pursuer:
 
 The `yaw_rate` and `pitch_rate` values for both agents are specified in
 degrees per second and are converted internally to radians per second.
+Similarly, the `stall_angle` parameter in `config.yaml` is given in
+degrees but converted to radians when the environment loads.

--- a/config.yaml
+++ b/config.yaml
@@ -19,8 +19,8 @@ evader:
   pitch_rate: 180.0
   # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
-  # Maximum allowable pitch angle [rad]
-  stall_angle: 1.0471975511965976
+  # Maximum allowable pitch angle [deg]
+  stall_angle: 60.0
 pursuer:
   # Mass of the pursuer [kg]
   mass: 1000.0
@@ -36,8 +36,8 @@ pursuer:
   pitch_rate: 270.0
   # Initial force direction
   up_vector: [0.0, 0.0, 1.0]
-  # Maximum allowable pitch angle [rad]
-  stall_angle: 1.3089969389957472
+  # Maximum allowable pitch angle [deg]
+  stall_angle: 75.0
 # Downward gravitational acceleration [m/s^2]
 gravity: 9.81
 # Simulation time step [s]

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -5,6 +5,7 @@ import torch.optim as optim
 import gymnasium as gym
 import yaml
 import os
+import copy
 
 
 
@@ -78,9 +79,17 @@ class PursuitEvasionEnv(gym.Env):
         """
 
         super().__init__()
-        self.cfg = cfg
-        self.dt = cfg['time_step']
-        self.shaping_weight = cfg.get('shaping_weight', 0.05)
+        # Make a copy so we can modify units without affecting the caller
+        self.cfg = copy.deepcopy(cfg)
+        self.dt = self.cfg['time_step']
+        self.shaping_weight = self.cfg.get('shaping_weight', 0.05)
+        # Convert stall angles provided in degrees to radians once
+        self.cfg['evader']['stall_angle'] = np.deg2rad(
+            self.cfg['evader']['stall_angle']
+        )
+        self.cfg['pursuer']['stall_angle'] = np.deg2rad(
+            self.cfg['pursuer']['stall_angle']
+        )
         # observation sizes depend on awareness mode
         self.evader_obs_dim = 9
         mode = cfg['evader'].get('awareness_mode', 1)


### PR DESCRIPTION
## Summary
- store stall angles in degrees in `config.yaml`
- convert stall_angle values to radians when initializing the environment
- mention stall_angle units in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py play.py`

------
https://chatgpt.com/codex/tasks/task_e_686e32dbb0908332865506626ee90746