### PR TITLE
Add episode metrics and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ which is useful for quickly checking that the environment works.
 - `play.py` loads a saved policy and runs a single episode. Use the `--ppo`
   flag when loading a model trained with the PPO script.
 
+The environment stores several statistics for each episode. When an episode
+finishes the ``info`` dictionary returned from ``env.step`` contains the
+closest pursuer--evader distance, number of steps and outcome (capture,
+evader reaching the target or timeout). The evaluation helpers in the training
+scripts print the average minimum distance and episode length during
+periodic evaluations.
+
 ## Adjusting environment parameters
 
 All physical constants and environment options are stored in

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -55,8 +55,15 @@ class PursuerOnlyEnv(gym.Env):
             {'pursuer': action, 'evader': e_action}
         )
         self.cur_step += 1
-        if self.cur_step >= self.max_steps:
+        if self.cur_step >= self.max_steps and not done:
             done = True
+            info.setdefault('episode_steps', self.cur_step)
+            info.setdefault('min_distance', float(self.env.min_pe_dist))
+            info.setdefault('final_distance', float(np.linalg.norm(self.env.evader_pos - self.env.pursuer_pos)))
+            target = np.array(self.env.cfg['target_position'], dtype=np.float32)
+            dist_target = np.linalg.norm(self.env.evader_pos - target)
+            info.setdefault('evader_to_target', float(dist_target))
+            info['outcome'] = 'timeout'
         return obs['pursuer'].astype(np.float32), float(reward['pursuer']), done, truncated, info
 
 
@@ -77,21 +84,33 @@ class ActorCritic(nn.Module):
 def evaluate(model: ActorCritic, env: PursuerOnlyEnv, episodes: int = 5):
     rewards = []
     successes = 0
+    min_dists = []
+    steps = []
     for _ in range(episodes):
         obs, _ = env.reset()
         done = False
         total = 0.0
+        info = {}
         while not done:
             with torch.no_grad():
                 obs_t = torch.tensor(obs, device=next(model.parameters()).device)
                 mean, _ = model(obs_t)
                 dist = torch.distributions.Normal(mean, torch.ones_like(mean))
                 action = dist.mean
-            obs, r, done, _, _ = env.step(action.cpu().numpy())
+            obs, r, done, _, info = env.step(action.cpu().numpy())
             total += r
         rewards.append(total)
         if total > 0:
             successes += 1
+        if info:
+            min_dists.append(info.get('min_distance', np.nan))
+            steps.append(info.get('episode_steps', np.nan))
+
+    if min_dists:
+        print(
+            f"    eval metrics: mean_min_dist={np.nanmean(min_dists):.2f} "
+            f"mean_steps={np.nanmean(steps):.1f}"
+        )
     return float(np.mean(rewards)), successes / episodes
 
 


### PR DESCRIPTION
## Summary
- track minimum distance and episode length in `PursuitEvasionEnv`
- surface metrics when `PursuerOnlyEnv` ends an episode
- report mean minimum distance and steps during evaluation
- display metrics in `play.py`
- document metrics in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py play.py`
- `python pursuit_evasion.py`
- `python train_pursuer.py --episodes 1 --eval-freq 1 --time-step 0.1`

------
https://chatgpt.com/codex/tasks/task_e_686e74ae34ac83329c791d6667bbb163