### PR TITLE
Add adjustable step limit for play.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ python pursuit_evasion.py
 which is useful for quickly checking that the environment works.
 
 - `play.py` loads a saved policy and runs a single episode. Use the `--ppo`
-  flag when loading a model trained with the PPO script.
+  flag when loading a model trained with the PPO script. The `--steps` option
+  controls how many simulation steps are executed before declaring a timeout.
 
 The environment stores several statistics for each episode. When an episode
 finishes the ``info`` dictionary returned from ``env.step`` contains the

--- a/play.py
+++ b/play.py
@@ -9,10 +9,10 @@ from train_pursuer import PursuerOnlyEnv
 from train_pursuer_ppo import ActorCritic
 
 
-def run_episode(model_path: str, use_ppo: bool = False) -> None:
+def run_episode(model_path: str, use_ppo: bool = False, max_steps: int = 20) -> None:
     cfg = load_config()
     cfg['evader']['awareness_mode'] = 1
-    env = PursuerOnlyEnv(cfg)
+    env = PursuerOnlyEnv(cfg, max_steps=max_steps)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     if use_ppo:
@@ -94,6 +94,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--ppo", action="store_true", help="load weights from PPO training"
     )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=60,
+        help="maximum number of steps before timing out",
+    )
     args = parser.parse_args()
 
-    run_episode(args.model, use_ppo=args.ppo)
+    run_episode(args.model, use_ppo=args.ppo, max_steps=args.steps)


### PR DESCRIPTION
## Summary
- enable setting the episode length when running `play.py`
- document the new `--steps` option in the README

## Testing
- `python -m py_compile play.py train_pursuer.py train_pursuer_ppo.py pursuit_evasion.py`

------
https://chatgpt.com/codex/tasks/task_e_686efa65ff2c83329855d839bdb5aa8e