### PR TITLE
Add episode duration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ python pursuit_evasion.py
 which is useful for quickly checking that the environment works.
 
 - `play.py` loads a saved policy and runs a single episode. Use the `--ppo`
-  flag when loading a model trained with the PPO script. The `--steps` option
-  controls how many simulation steps are executed before declaring a timeout.
+  flag when loading a model trained with the PPO script. Episodes run for the
+  duration specified by `episode_duration` in `config.yaml` unless `--steps` is
+  used to override the maximum number of simulation steps.
   The plot now highlights the starting and final positions of both agents and
   marks the evader's goal position.
 
@@ -106,4 +107,7 @@ evader receives about the pursuer:
 The `yaw_rate` and `pitch_rate` values for both agents are specified in
 degrees per second and are converted internally to radians per second.
 Similarly, the `stall_angle` parameter in `config.yaml` is given in
-degrees but converted to radians when the environment loads.
+degrees but converted to radians when the environment loads. The
+`episode_duration` value defines how long each episode lasts in minutes and
+is used to compute the maximum number of simulation steps based on the
+configured `time_step`.

--- a/config.yaml
+++ b/config.yaml
@@ -42,6 +42,8 @@ pursuer:
 gravity: 9.81
 # Simulation time step [s]
 time_step: 0.1
+# Duration of one episode [min]
+episode_duration: 0.1
 # Distance at which capture is considered successful [m]
 capture_radius: 1.0
 # Weight for shaping rewards

--- a/play.py
+++ b/play.py
@@ -9,7 +9,7 @@ from train_pursuer import PursuerOnlyEnv
 from train_pursuer_ppo import ActorCritic
 
 
-def run_episode(model_path: str, use_ppo: bool = False, max_steps: int = 20) -> None:
+def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = None) -> None:
     cfg = load_config()
     cfg['evader']['awareness_mode'] = 1
     env = PursuerOnlyEnv(cfg, max_steps=max_steps)
@@ -53,6 +53,7 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int = 20) -> 
         print(
             f"Steps: {info.get('episode_steps', 'n/a')}  "
             f"closest={closest}  "
+            f"start={info.get('start_distance', float('nan')):.2f}  "
             f"outcome={info.get('outcome', 'unknown')}"
         )
 
@@ -137,8 +138,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--steps",
         type=int,
-        default=60,
-        help="maximum number of steps before timing out",
+        default=None,
+        help="override maximum episode steps",
     )
     args = parser.parse_args()
 

--- a/plot_config.py
+++ b/plot_config.py
@@ -109,6 +109,7 @@ def main():
     global_txt = (
         f"gravity: {cfg['gravity']} m/s^2\n"
         f"time step: {cfg['time_step']} s\n"
+        f"episode duration: {cfg.get('episode_duration', 0.0)} min\n"
         f"shaping weight: {cfg['shaping_weight']}\n"
     )
     fig.text(0.01, 0.95, evader_txt, fontsize=9, va="top")

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -158,6 +158,8 @@ class PursuitEvasionEnv(gym.Env):
         self.pursuer_force_mag = 0.0
         # record baseline distances for shaping rewards
         self.prev_pe_dist = np.linalg.norm(self.evader_pos - self.pursuer_pos)
+        # store the starting distance for logging
+        self.start_pe_dist = self.prev_pe_dist
         target = np.array(self.cfg['target_position'], dtype=np.float32)
         self.prev_target_dist = np.linalg.norm(self.evader_pos - target)
         # metrics for episode statistics
@@ -201,6 +203,7 @@ class PursuitEvasionEnv(gym.Env):
                 'min_distance': float(self.min_pe_dist),
                 'final_distance': float(dist_pe),
                 'evader_to_target': float(dist_target),
+                'start_distance': float(self.start_pe_dist),
             }
             if dist_pe <= self.cfg['capture_radius']:
                 info['outcome'] = 'capture'

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -36,17 +36,22 @@ def evader_policy(env: PursuitEvasionEnv) -> np.ndarray:
 class PursuerOnlyEnv(gym.Env):
     """Environment exposing only the pursuer."""
 
-    def __init__(self, cfg: dict, max_steps: int = 20):
+    def __init__(self, cfg: dict, max_steps: int | None = None):
         super().__init__()
         self.env = PursuitEvasionEnv(cfg)
         self.observation_space = self.env.observation_space['pursuer']
         self.action_space = self.env.action_space['pursuer']
-        self.max_steps = max_steps
+        if max_steps is None:
+            duration = cfg.get('episode_duration', 0.1)
+            self.max_steps = int(duration * 60.0 / cfg['time_step'])
+        else:
+            self.max_steps = max_steps
         self.cur_step = 0
 
     def reset(self, *, seed=None, options=None):
         obs, info = self.env.reset(seed=seed)
         self.cur_step = 0
+        self.start_distance = self.env.start_pe_dist
         return obs['pursuer'].astype(np.float32), info
 
     def step(self, action: np.ndarray):
@@ -54,6 +59,7 @@ class PursuerOnlyEnv(gym.Env):
         obs, reward, done, truncated, info = self.env.step(
             {'pursuer': action, 'evader': e_action}
         )
+        info.setdefault('start_distance', float(self.env.start_pe_dist))
         self.cur_step += 1
         if self.cur_step >= self.max_steps and not done:
             done = True
@@ -63,6 +69,7 @@ class PursuerOnlyEnv(gym.Env):
             target = np.array(self.env.cfg['target_position'], dtype=np.float32)
             dist_target = np.linalg.norm(self.env.evader_pos - target)
             info.setdefault('evader_to_target', float(dist_target))
+            info.setdefault('start_distance', float(self.env.start_pe_dist))
             info['outcome'] = 'timeout'
         return obs['pursuer'].astype(np.float32), float(reward['pursuer']), done, truncated, info
 
@@ -138,13 +145,15 @@ def train(cfg: dict, save_path: Optional[str] = None):
         rewards = []
         obs_list = []
         actions = []
+        info = {}
+        start_d = env.start_distance
         while not done:
             obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
             mean, value = model(obs_t)
             dist = torch.distributions.Normal(mean, torch.ones_like(mean))
             action = dist.sample()
             log_prob = dist.log_prob(action).sum()
-            next_obs, r, done, _, _ = env.step(action.cpu().numpy())
+            next_obs, r, done, _, info = env.step(action.cpu().numpy())
             log_probs.append(log_prob.detach())
             values.append(value.detach())
             rewards.append(r)
@@ -181,6 +190,12 @@ def train(cfg: dict, save_path: Optional[str] = None):
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
+
+        if info:
+            print(
+                f"Episode {episode+1}: outcome={info.get('outcome', 'timeout')} "
+                f"start={start_d:.2f} min={info.get('min_distance', float('nan')):.2f}"
+            )
 
         if (episode + 1) % eval_freq == 0:
             avg_r, success = evaluate(model, PursuerOnlyEnv(cfg))


### PR DESCRIPTION
## Summary
- allow specifying episode_duration in config.yaml (minutes)
- compute max steps from duration in training and play
- print episode outcome with starting and minimum distance during training
- expose start distance info on timeout and termination
- document new option in README and show in plot_config

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py play.py plot_config.py`

------
https://chatgpt.com/codex/tasks/task_e_686f0428f0b88332ac2e087296dd9ddb