### PR TITLE
Implement separation-based episode end

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ which is useful for quickly checking that the environment works.
 The environment stores several statistics for each episode. When an episode
 finishes the ``info`` dictionary returned from ``env.step`` contains the
 closest pursuer--evader distance, number of steps and outcome (capture,
-evader reaching the target or timeout). The evaluation helpers in the training
+evader reaching the target, separation exceeding twice the starting distance or timeout). The evaluation helpers in the training
 scripts print the average minimum distance and episode length during
 periodic evaluations.
 

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -209,6 +209,8 @@ class PursuitEvasionEnv(gym.Env):
                 info['outcome'] = 'capture'
             elif self.evader_pos[2] <= 0.0 and dist_target < self.cfg['capture_radius'] * 5:
                 info['outcome'] = 'evader_target'
+            elif dist_pe >= 2 * self.start_pe_dist:
+                info['outcome'] = 'separation_exceeded'
 
         self.cur_step += 1
         return obs, reward, done, False, info
@@ -287,6 +289,8 @@ class PursuitEvasionEnv(gym.Env):
         dist = np.linalg.norm(self.evader_pos - self.pursuer_pos)
         if dist <= self.cfg['capture_radius']:
             return True, -1.0, 1.0
+        if dist >= 2 * self.start_pe_dist:
+            return True, 0.0, 0.0
         # check if the evader hit the ground near the target
         target = np.array(self.cfg['target_position'], dtype=np.float32)
         if (self.evader_pos[2] <= 0.0 and np.linalg.norm(self.evader_pos - target) < self.cfg['capture_radius'] * 5):


### PR DESCRIPTION
## Summary
- terminate when pursuer and evader are twice their initial distance apart
- label the outcome as `separation_exceeded`
- document new episode ending condition in README

## Testing
- `pip install -r requirements.txt`
- `python pursuit_evasion.py`

------
https://chatgpt.com/codex/tasks/task_e_686f80ef24f8833288f3419be2eff7c6