### PR TITLE
Spawn pursuer heading toward target

### DIFF
--- a/play.py
+++ b/play.py
@@ -66,10 +66,8 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = 
     ax.plot(e[:, 0], e[:, 1], e[:, 2], label="evader")
     # draw arrows showing the initial heading for both agents
     arrow_len = 1000.0
-    p_dir = env.env.pursuer_vel
-    p_norm = np.linalg.norm(p_dir)
-    if p_norm > 1e-6:
-        p_dir = p_dir / p_norm
+    p_dir = env.env.pursuer_force_dir
+    p_dir = p_dir / (np.linalg.norm(p_dir) + 1e-8)
     e_dir = env.env.evader_force_dir
     e_dir = e_dir / (np.linalg.norm(e_dir) + 1e-8)
     ax.quiver(

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -36,16 +36,13 @@ def sample_pursuer_start(evader_pos: np.ndarray, cfg: dict):
     r = np.random.uniform(params['min_range'], params['max_range'])
     yaw = np.random.uniform(0.0, 2 * np.pi)
     pitch = np.random.uniform(0.0, cone)
-    # direction from evader to pursuer in world frame (beneath the evader)
+    # direction from the evader to the pursuer in world coordinates
     dir_vec = np.array([
         np.sin(pitch) * np.cos(yaw),
         np.sin(pitch) * np.sin(yaw),
         -np.cos(pitch),
     ], dtype=np.float32)
     pos = evader_pos + dir_vec * r
-
-    speed = np.random.uniform(*params['initial_speed_range'])
-    vel = dir_vec * speed
 
     # point the initial force vector toward a random point near the evader
     tgt_offset = np.random.randn(3).astype(np.float32)
@@ -54,6 +51,10 @@ def sample_pursuer_start(evader_pos: np.ndarray, cfg: dict):
     tgt = evader_pos + tgt_offset
     to_tgt = tgt - pos
     to_tgt /= np.linalg.norm(to_tgt) + 1e-8
+
+    speed = np.random.uniform(*params['initial_speed_range'])
+    # initial velocity aligned with the chosen target direction
+    vel = to_tgt * speed
     return pos, vel, to_tgt
 
 


### PR DESCRIPTION
## Summary
- align the pursuer's initial velocity with the random target direction in `sample_pursuer_start`
- draw the pursuer's heading arrow using the force direction

## Testing
- `python -m py_compile pursuit_evasion.py`
- `python -m py_compile play.py`


------
https://chatgpt.com/codex/tasks/task_e_686f8f5bb33c83329baafa942f02710e