### PR TITLE
Update termination logic and plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,9 @@ their pitch commands to ``[-stall_angle, +stall_angle]``. The
 `episode_duration` value defines how long each episode lasts in minutes and
 is used to compute the maximum number of simulation steps based on the
 configured `time_step`.
+
+When either agent touches the ground the episode terminates. If the evader
+hits the ground its terminal reward scales with the distance to the target
+using ``target_reward_distance``. A reward of one is given when it reaches the
+goal and it falls off to zero once the evader is roughly 100&nbsp;m away by
+default.

--- a/config.yaml
+++ b/config.yaml
@@ -46,6 +46,8 @@ time_step: 0.1
 episode_duration: 40
 # Distance at which capture is considered successful [m]
 capture_radius: 1.0
+# Distance within which the evader receives reward when hitting the ground [m]
+target_reward_distance: 100.0
 # Weight for shaping rewards
 shaping_weight: 0.05
 # Coordinates of the evader's goal [m]

--- a/play.py
+++ b/play.py
@@ -25,6 +25,9 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = 
     model.eval()
 
     obs, _ = env.reset()
+    # store initial headings before the environment steps
+    p_init_dir = env.env.pursuer_force_dir.copy()
+    e_init_dir = env.env.evader_force_dir.copy()
     # collect positions for plotting
     pursuer_traj = [env.env.pursuer_pos.copy()]
     evader_traj = [env.env.evader_pos.copy()]
@@ -66,10 +69,8 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = 
     ax.plot(e[:, 0], e[:, 1], e[:, 2], label="evader")
     # draw arrows showing the initial heading for both agents
     arrow_len = 1000.0
-    p_dir = env.env.pursuer_force_dir
-    p_dir = p_dir / (np.linalg.norm(p_dir) + 1e-8)
-    e_dir = env.env.evader_force_dir
-    e_dir = e_dir / (np.linalg.norm(e_dir) + 1e-8)
+    p_dir = p_init_dir / (np.linalg.norm(p_init_dir) + 1e-8)
+    e_dir = e_init_dir / (np.linalg.norm(e_init_dir) + 1e-8)
     ax.quiver(
         p[0, 0],
         p[0, 1],


### PR DESCRIPTION
## Summary
- episode ends when either aircraft goes below ground
- reward for the evader when hitting the ground is based on distance to the target
- store initial heading when plotting episode playthrough
- document new `target_reward_distance` option

## Testing
- `python -m py_compile pursuit_evasion.py play.py train_pursuer.py train_pursuer_ppo.py`
- `pip install numpy torch gymnasium matplotlib pyyaml` *(fails: network)*

------
https://chatgpt.com/codex/tasks/task_e_686fa6b16578833299e644a73e689b31