### PR TITLE
Add spawn volume configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ which is useful for quickly checking that the environment works.
   marks the evader's goal position and draws arrows indicating the initial
   heading of both players. During the run a table prints the distance vectors
   between the players and the goal along with the current velocities for both
-  agents.
+  agents. The spawn volume for the pursuer is drawn using dashed green lines so
+  you can verify the configuration visually.
+- `plot_config.py` renders a stand-alone visualisation of the environment
+  configuration including the spawn volume. The accompanying
+  `SpawnVolumeDemo.ipynb` notebook calls this script so you can interactively
+  adjust `config.yaml` and inspect the effect.
 
 The environment stores several statistics for each episode. When an episode
 finishes the ``info`` dictionary returned from ``env.step`` contains the
@@ -98,6 +103,17 @@ the pursuer.  The evader's starting position is also randomised using
 the `evader_start.distance_range` and `evader_start.altitude` settings,
 while `evader_start.initial_speed` controls its initial velocity toward
 the target (within ±15° of the exact bearing).
+
+The pursuer's starting position is sampled inside a configurable volume.
+`pursuer_start.cone_half_angle` sets the outer limit of the spawn cone
+below the evader while `pursuer_start.inner_cone_half_angle` specifies an
+inner cutoff to avoid very steep spawn angles.  The `sections` dictionary
+divides the horizontal plane around the evader into four 90° quadrants
+(`front`, `right`, `back`, `left`) relative to the evader's initial
+heading.  Each section can be enabled or disabled to further restrict the
+spawn volume.  Combined with the `min_range` and `max_range` distances
+these options define where the pursuer may appear at the beginning of an
+episode.
 Both `pursuit_evasion.py` and `train_pursuer.py` load the configuration
 at runtime, so changes take effect the next time you run the scripts.
 

--- a/SpawnVolumeDemo.ipynb
+++ b/SpawnVolumeDemo.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spawn volume visualization\n",
+    "This notebook shows the pursuer spawn volume defined by the inner/outer cones and the enabled quadrants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plot_config\n",
+    "plot_config.main()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adjust `config.yaml` and re-run the cell above to see how the spawn volume changes." 
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,14 @@ evader_start:
 pursuer_start:
   # Maximum half angle of the pursuer spawn cone [rad]
   cone_half_angle: 1.4
+  # Minimum half angle of the pursuer spawn cone [rad]
+  inner_cone_half_angle: 0.3
+  # Enable or disable spawn quadrants relative to the evader heading
+  sections:
+    front: true
+    left: true
+    right: true
+    back: true
   # Minimum initial range from the evader [m]
   min_range: 1000.0
   # Maximum initial range from the evader [m]


### PR DESCRIPTION
## Summary
- add inner cone and quadrant selection for pursuer start
- visualise spawn volume in play and plot scripts
- describe the new options in README and add a demo notebook

## Testing
- `python -m py_compile pursuit_evasion.py play.py plot_config.py train_pursuer.py train_pursuer_ppo.py`
- `python plot_config.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686fb12818ec8332a5dc8d099e850b9c