### PR TITLE
Print table rows after each training episode

### DIFF
--- a/train_pursuer.py
+++ b/train_pursuer.py
@@ -6,6 +6,35 @@ import torch.optim as optim
 import gymnasium as gym
 from typing import Optional
 
+TABLE_HEADER = (
+    f"{'step':>5} | {'pursuer→evader [m]':>26} | "
+    f"{'evader→target [m]':>26} | {'pursuer vel [m/s]':>26} | "
+    f"{'evader vel [m/s]':>26} | {'p dir':>18} | "
+    f"{'e dir':>18} | {'p→e dir':>18}"
+)
+
+
+def _format_row(step: int, env: PursuitEvasionEnv) -> str:
+    """Return a formatted table row showing current vectors and velocities."""
+    target_pos = np.asarray(env.cfg["target_position"], dtype=float)
+    pe_vec = env.evader_pos - env.pursuer_pos
+    et_vec = target_pos - env.evader_pos
+    pv = env.pursuer_vel
+    ev = env.evader_vel
+    pv_u = pv / (np.linalg.norm(pv) + 1e-8)
+    ev_u = ev / (np.linalg.norm(ev) + 1e-8)
+    pe_u = pe_vec / (np.linalg.norm(pe_vec) + 1e-8)
+    return (
+        f"{step:5d} | "
+        f"[{pe_vec[0]:7.1f} {pe_vec[1]:7.1f} {pe_vec[2]:7.1f}] | "
+        f"[{et_vec[0]:7.1f} {et_vec[1]:7.1f} {et_vec[2]:7.1f}] | "
+        f"[{pv[0]:7.1f} {pv[1]:7.1f} {pv[2]:7.1f}] | "
+        f"[{ev[0]:7.1f} {ev[1]:7.1f} {ev[2]:7.1f}] | "
+        f"[{pv_u[0]:6.2f} {pv_u[1]:6.2f} {pv_u[2]:6.2f}] | "
+        f"[{ev_u[0]:6.2f} {ev_u[1]:6.2f} {ev_u[2]:6.2f}] | "
+        f"[{pe_u[0]:6.2f} {pe_u[1]:6.2f} {pe_u[2]:6.2f}]"
+    )
+
 from pursuit_evasion import PursuitEvasionEnv, PursuerPolicy, load_config
 
 # Load configuration and set the evader to be unaware
@@ -138,6 +167,7 @@ def train(cfg: dict, save_path: Optional[str] = None):
         rewards = []
         done = False
         info = {}
+        rows = []
         start_d = env.start_distance
         while not done:
             obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
@@ -146,6 +176,7 @@ def train(cfg: dict, save_path: Optional[str] = None):
             action = dist.sample()
             log_prob = dist.log_prob(action).sum()
             obs, r, done, _, info = env.step(action.cpu().numpy())
+            rows.append(_format_row(len(rows), env.env))
             log_probs.append(log_prob)
             rewards.append(r)
         # Compute discounted returns
@@ -165,6 +196,13 @@ def train(cfg: dict, save_path: Optional[str] = None):
                 f"Episode {episode+1}: outcome={info.get('outcome', 'timeout')} "
                 f"start={start_d:.2f} min={info.get('min_distance', float('nan')):.2f}"
             )
+            print(TABLE_HEADER)
+            for row in rows[:3]:
+                print(row)
+            if len(rows) > 6:
+                print("...")
+            for row in rows[-3:]:
+                print(row)
         if (episode + 1) % eval_freq == 0:
             # Periodically report progress on separate evaluation episodes
             avg_r, success = evaluate(policy, PursuerOnlyEnv(config))

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -6,6 +6,34 @@ import torch.optim as optim
 import gymnasium as gym
 from typing import Optional
 
+TABLE_HEADER = (
+    f"{'step':>5} | {'pursuer→evader [m]':>26} | "
+    f"{'evader→target [m]':>26} | {'pursuer vel [m/s]':>26} | "
+    f"{'evader vel [m/s]':>26} | {'p dir':>18} | "
+    f"{'e dir':>18} | {'p→e dir':>18}"
+)
+
+
+def _format_row(step: int, env: PursuitEvasionEnv) -> str:
+    target_pos = np.asarray(env.cfg["target_position"], dtype=float)
+    pe_vec = env.evader_pos - env.pursuer_pos
+    et_vec = target_pos - env.evader_pos
+    pv = env.pursuer_vel
+    ev = env.evader_vel
+    pv_u = pv / (np.linalg.norm(pv) + 1e-8)
+    ev_u = ev / (np.linalg.norm(ev) + 1e-8)
+    pe_u = pe_vec / (np.linalg.norm(pe_vec) + 1e-8)
+    return (
+        f"{step:5d} | "
+        f"[{pe_vec[0]:7.1f} {pe_vec[1]:7.1f} {pe_vec[2]:7.1f}] | "
+        f"[{et_vec[0]:7.1f} {et_vec[1]:7.1f} {et_vec[2]:7.1f}] | "
+        f"[{pv[0]:7.1f} {pv[1]:7.1f} {pv[2]:7.1f}] | "
+        f"[{ev[0]:7.1f} {ev[1]:7.1f} {ev[2]:7.1f}] | "
+        f"[{pv_u[0]:6.2f} {pv_u[1]:6.2f} {pv_u[2]:6.2f}] | "
+        f"[{ev_u[0]:6.2f} {ev_u[1]:6.2f} {ev_u[2]:6.2f}] | "
+        f"[{pe_u[0]:6.2f} {pe_u[1]:6.2f} {pe_u[2]:6.2f}]"
+    )
+
 from pursuit_evasion import (
     PursuitEvasionEnv,
     PursuerPolicy,
@@ -146,6 +174,7 @@ def train(cfg: dict, save_path: Optional[str] = None):
         obs_list = []
         actions = []
         info = {}
+        rows = []
         start_d = env.start_distance
         while not done:
             obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
@@ -154,6 +183,7 @@ def train(cfg: dict, save_path: Optional[str] = None):
             action = dist.sample()
             log_prob = dist.log_prob(action).sum()
             next_obs, r, done, _, info = env.step(action.cpu().numpy())
+            rows.append(_format_row(len(rows), env.env))
             log_probs.append(log_prob.detach())
             values.append(value.detach())
             rewards.append(r)
@@ -196,6 +226,13 @@ def train(cfg: dict, save_path: Optional[str] = None):
                 f"Episode {episode+1}: outcome={info.get('outcome', 'timeout')} "
                 f"start={start_d:.2f} min={info.get('min_distance', float('nan')):.2f}"
             )
+            print(TABLE_HEADER)
+            for row in rows[:3]:
+                print(row)
+            if len(rows) > 6:
+                print("...")
+            for row in rows[-3:]:
+                print(row)
 
         if (episode + 1) % eval_freq == 0:
             avg_r, success = evaluate(model, PursuerOnlyEnv(cfg))


### PR DESCRIPTION
## Summary
- show table row formatting helpers in training scripts
- print first and last three table rows for each episode of REINFORCE or PPO training

## Testing
- `python -m py_compile train_pursuer.py train_pursuer_ppo.py play.py pursuit_evasion.py plot_config.py`

------
https://chatgpt.com/codex/tasks/task_e_686fd5d212b88332a4fc121eaee7193c