### PR TITLE
Add table logging to training scripts

### DIFF
--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -18,6 +18,28 @@ config = load_config()
 config['evader']['awareness_mode'] = 1
 
 
+def _format_step(env: PursuerOnlyEnv, step: int, target: np.ndarray) -> str:
+    """Return formatted row for the table shown in ``play.py``."""
+
+    pe_vec = env.env.evader_pos - env.env.pursuer_pos
+    et_vec = target - env.env.evader_pos
+    pv = env.env.pursuer_vel
+    ev = env.env.evader_vel
+    pv_u = pv / (np.linalg.norm(pv) + 1e-8)
+    ev_u = ev / (np.linalg.norm(ev) + 1e-8)
+    pe_u = pe_vec / (np.linalg.norm(pe_vec) + 1e-8)
+    return (
+        f"{step:5d} | "
+        f"[{pe_vec[0]:7.1f} {pe_vec[1]:7.1f} {pe_vec[2]:7.1f}] | "
+        f"[{et_vec[0]:7.1f} {et_vec[1]:7.1f} {et_vec[2]:7.1f}] | "
+        f"[{pv[0]:7.1f} {pv[1]:7.1f} {pv[2]:7.1f}] | "
+        f"[{ev[0]:7.1f} {ev[1]:7.1f} {ev[2]:7.1f}] | "
+        f"[{pv_u[0]:6.2f} {pv_u[1]:6.2f} {pv_u[2]:6.2f}] | "
+        f"[{ev_u[0]:6.2f} {ev_u[1]:6.2f} {ev_u[2]:6.2f}] | "
+        f"[{pe_u[0]:6.2f} {pe_u[1]:6.2f} {pe_u[2]:6.2f}]"
+    )
+
+
 def evader_policy(env: PursuitEvasionEnv) -> np.ndarray:
     """Evader accelerates toward the target."""
     pos = env.evader_pos
@@ -137,6 +159,13 @@ def train(cfg: dict, save_path: Optional[str] = None):
     ppo_epochs = 4
     entropy_coef = 0.01
 
+    header = (
+        f"{'step':>5} | {'pursuer→evader [m]':>26} | "
+        f"{'evader→target [m]':>26} | {'pursuer vel [m/s]':>26} | "
+        f"{'evader vel [m/s]':>26} | {'p dir':>18} | {'e dir':>18} | "
+        f"{'p→e dir':>18}"
+    )
+
     for episode in range(num_episodes):
         obs, _ = env.reset()
         done = False
@@ -147,6 +176,10 @@ def train(cfg: dict, save_path: Optional[str] = None):
         actions = []
         info = {}
         start_d = env.start_distance
+        target = np.asarray(env.env.cfg["target_position"], dtype=float)
+        first_rows: list[str] = []
+        last_rows: list[str] = []
+        step = 0
         while not done:
             obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
             mean, value = model(obs_t)
@@ -159,7 +192,14 @@ def train(cfg: dict, save_path: Optional[str] = None):
             rewards.append(r)
             obs_list.append(obs_t)
             actions.append(action)
+            row = _format_step(env, step, target)
+            if len(first_rows) < 3:
+                first_rows.append(row)
+            if len(last_rows) >= 3:
+                last_rows.pop(0)
+            last_rows.append(row)
             obs = next_obs
+            step += 1
 
         # compute returns and advantages
         returns = []
@@ -191,6 +231,12 @@ def train(cfg: dict, save_path: Optional[str] = None):
             loss.backward()
             optimizer.step()
 
+        print(header)
+        print("-" * len(header))
+        for row in first_rows:
+            print(row)
+        for row in last_rows:
+            print(row)
         if info:
             print(
                 f"Episode {episode+1}: outcome={info.get('outcome', 'timeout')} "


### PR DESCRIPTION
## Summary
- format step rows in both training scripts
- output first and last 3 step rows for each episode in REINFORCE and PPO trainers

## Testing
- `pytest -q`
- `python -m py_compile train_pursuer.py train_pursuer_ppo.py`

------
https://chatgpt.com/codex/tasks/task_e_686fd5d212b88332a4fc121eaee7193c