### PR TITLE
Allow braking for pursuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Similarly, the `stall_angle` parameter in `config.yaml` is given in
 degrees but converted to radians when the environment loads. Actions
 specify yaw and **pitch** where pitch is measured relative to the horizontal
 x–y plane (positive values command an upward climb). Both agents clamp
-their pitch commands to ``[-stall_angle, +stall_angle]``. The
+their pitch commands to ``[-stall_angle, +stall_angle]``. The first action
+component controls acceleration. The pursuer may command negative values
+down to ``-max_acceleration`` to brake. The
 `episode_duration` value defines how long each episode lasts in minutes and
 is used to compute the maximum number of simulation steps based on the
 configured `time_step`.

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,7 @@ pursuer:
   mass: 100.0
   # Maximum acceleration magnitude [m/s^2]
   max_acceleration: 30.0
+  # Acceleration can be negative allowing the pursuer to brake
   # Upper speed limit [m/s]
   top_speed: 150.0
   # Dimensionless coefficient modelling drag

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -146,7 +146,11 @@ class PursuitEvasionEnv(gym.Env):
         self.action_space = gym.spaces.Dict({
             # actions: [acceleration magnitude, azimuth, pitch]
             'pursuer': gym.spaces.Box(
-                low=np.array([0.0, -np.pi, -cfg['pursuer']['stall_angle']], dtype=np.float32),
+                low=np.array([
+                    -cfg['pursuer']['max_acceleration'],
+                    -np.pi,
+                    -cfg['pursuer']['stall_angle'],
+                ], dtype=np.float32),
                 high=np.array([
                     cfg['pursuer']['max_acceleration'],
                     np.pi,
@@ -297,7 +301,7 @@ class PursuitEvasionEnv(gym.Env):
             dir_vec = self.pursuer_force_dir
             gravity = np.zeros(3, dtype=np.float32)
 
-        mag = float(np.clip(action[0], 0.0, max_acc))
+        mag = float(np.clip(action[0], -max_acc, max_acc))
         theta = float(action[1])
         phi = float(np.clip(action[2], -stall, stall))
         target_dir = np.array([


### PR DESCRIPTION
## Summary
- enable negative acceleration for pursuer actions
- clip acceleration to symmetric range in `_update_agent`
- document braking support in config and README

## Testing
- `python -m py_compile pursuit_evasion.py`
- `python pursuit_evasion.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687038c0a1d88332ad2446bd6789be31