### PR TITLE
Fix drag computation based on velocity

### DIFF
--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -332,10 +332,10 @@ class PursuitEvasionEnv(gym.Env):
             self.pursuer_force_dir = new_dir
             self.pursuer_force_mag = mag
 
-        # Compute acceleration in world frame. Drag always opposes thrust and
-        # gravity only affects the evader.
+        # Compute acceleration in world frame. Drag opposes the current
+        # velocity while gravity only affects the evader.
         acc_cmd = new_dir * mag
-        drag = -drag_c * new_dir
+        drag = -drag_c * vel
         acc_total = acc_cmd + drag + gravity
 
         # Simple Euler integration of velocity and position


### PR DESCRIPTION
## Summary
- compute drag opposite to current velocity in `_update_agent`
- update comments to match corrected drag behaviour

## Testing
- `pip install -r requirements.txt`
- `python pursuit_evasion.py`

------
https://chatgpt.com/codex/tasks/task_e_687038c75e248332a6da40bdcd453737