### PR TITLE
Print starting positions

### DIFF
--- a/train_pursuer.py
+++ b/train_pursuer.py
@@ -185,6 +185,8 @@ def train(
     for episode in range(num_episodes):
         # Collect one episode of experience
         obs, _ = env.reset()
+        init_pursuer_pos = env.env.pursuer_pos.copy()
+        init_evader_pos = env.env.evader_pos.copy()
         log_probs = []
         rewards = []
         done = False
@@ -223,6 +225,8 @@ def train(
         loss.backward()
         optimizer.step()
 
+        print(f"Initial pursuer pos: {init_pursuer_pos}")
+        print(f"Initial evader pos: {init_evader_pos}")
         print(header)
         print("-" * len(header))
         for row in first_rows:

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -186,6 +186,8 @@ def train(
 
     for episode in range(num_episodes):
         obs, _ = env.reset()
+        init_pursuer_pos = env.env.pursuer_pos.copy()
+        init_evader_pos = env.env.evader_pos.copy()
         done = False
         log_probs = []
         values = []
@@ -249,6 +251,8 @@ def train(
             loss.backward()
             optimizer.step()
 
+        print(f"Initial pursuer pos: {init_pursuer_pos}")
+        print(f"Initial evader pos: {init_evader_pos}")
         print(header)
         print("-" * len(header))
         for row in first_rows:


### PR DESCRIPTION
## Summary
- show start positions of the pursuer and evader in both training loops
- minor script test via py_compile

## Testing
- `python -m py_compile train_pursuer.py train_pursuer_ppo.py`
- `python train_pursuer.py --episodes 1 --time-step 0.1 --eval-freq 1 --save-path /tmp/model.pt`
- `python train_pursuer_ppo.py --episodes 1 --time-step 0.1 --eval-freq 1 --save-path /tmp/model.pt`


------
https://chatgpt.com/codex/tasks/task_e_68703d21f1b083329ba6e8c8fdf773df