### PR TITLE
Add dive trajectory mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ x–y plane (positive values command an upward climb). Both agents clamp
 their pitch commands to ``[-stall_angle, +stall_angle]``. The first action
 component controls acceleration. The pursuer may command negative values
 down to ``-max_acceleration`` to brake. The
+``evader.trajectory`` option selects a preset flight profile. When set to
+``"dive"`` the evader keeps a non-negative pitch until the line of sight to the
+target drops below ``evader.dive_angle`` (specified in degrees). Once past this
+threshold the evader begins descending toward the goal. The
 `episode_duration` value defines how long each episode lasts in minutes and
 is used to compute the maximum number of simulation steps based on the
 configured `time_step`.

--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,11 @@ evader:
   up_vector: [0.0, 0.0, 1.0]
   # Maximum allowable pitch angle [deg]
   stall_angle: 45.0
+  # Preset trajectory mode. Use "dive" to level off until the dive angle
+  # threshold is reached
+  trajectory: direct
+  # Angle to the target at which the evader begins its dive [deg]
+  dive_angle: 20.0
 pursuer:
   # Mass of the pursuer [kg]
   mass: 100.0

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -124,6 +124,10 @@ class PursuitEvasionEnv(gym.Env):
         self.cfg['evader']['stall_angle'] = np.deg2rad(
             self.cfg['evader']['stall_angle']
         )
+        if 'dive_angle' in self.cfg['evader']:
+            self.cfg['evader']['dive_angle'] = np.deg2rad(
+                self.cfg['evader']['dive_angle']
+            )
         self.cfg['pursuer']['stall_angle'] = np.deg2rad(
             self.cfg['pursuer']['stall_angle']
         )

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -45,7 +45,7 @@ def _format_step(env: PursuerOnlyEnv, step: int, target: np.ndarray) -> str:
 
 
 def evader_policy(env: PursuitEvasionEnv) -> np.ndarray:
-    """Evader accelerates toward the target."""
+    """Evader accelerates toward the target with optional dive profile."""
     pos = env.evader_pos
     target = np.array(env.cfg['target_position'], dtype=np.float32)
     direction = target - pos
@@ -53,7 +53,16 @@ def evader_policy(env: PursuitEvasionEnv) -> np.ndarray:
     if norm > 1e-8:
         direction /= norm
     theta = np.arctan2(direction[1], direction[0])
-    phi = np.arctan2(direction[2], np.linalg.norm(direction[:2]))
+    phi_target = np.arctan2(direction[2], np.linalg.norm(direction[:2]))
+    mode = env.cfg['evader'].get('trajectory', 'direct')
+    if mode == 'dive':
+        threshold = env.cfg['evader'].get('dive_angle', 0.0)
+        if phi_target > -threshold:
+            phi = max(0.0, phi_target)
+        else:
+            phi = phi_target
+    else:
+        phi = phi_target
     phi = np.clip(phi, -env.cfg['evader']['stall_angle'], env.cfg['evader']['stall_angle'])
     mag = env.cfg['evader']['max_acceleration']
     return np.array([mag, theta, phi], dtype=np.float32)


### PR DESCRIPTION
## Summary
- support `dive` trajectory for the evader
- document new config options

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: network)*

------
https://chatgpt.com/codex/tasks/task_e_6870488239d08332a5096464df6709d4