### PR TITLE
Remove spawn volume surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ which is useful for quickly checking that the environment works.
   marks the evader's goal position and draws arrows indicating the initial
   heading of both players. During the run a table prints the distance vectors
   between the players and the goal along with the current velocities for both
-  agents. The spawn volume for the pursuer is drawn using translucent green
-  surfaces so you can verify the configuration visually.
+  agents. The spawn volume for the pursuer is now outlined with green lines
+  only (surface fills were removed to keep the plot responsive).
 - `plot_config.py` renders a stand-alone visualisation of the environment
-  configuration including the closed spawn volume. The accompanying
+  configuration showing an outline of the spawn volume. The accompanying
   `SpawnVolumeDemo.ipynb` notebook calls this script so you can interactively
   adjust `config.yaml` and inspect the effect.
 

--- a/play.py
+++ b/play.py
@@ -49,45 +49,9 @@ def draw_spawn_volume(
                 z = apex[2] - np.array([r_min, r_max]) * np.cos(inner)
                 ax.plot(x, y, z, **line_kw)
 
-        t = np.linspace(yaw_start, yaw_end, 30)
-        r = np.linspace(r_min, r_max, 10)
-        T, R = np.meshgrid(t, r)
-        xo = apex[0] + R * np.sin(outer) * np.cos(T)
-        yo = apex[1] + R * np.sin(outer) * np.sin(T)
-        zo = apex[2] - R * np.cos(outer)
-        ax.plot_surface(xo, yo, zo, color=color, alpha=alpha, linewidth=0)
-        if inner > 0:
-            xi = apex[0] + R * np.sin(inner) * np.cos(T)
-            yi = apex[1] + R * np.sin(inner) * np.sin(T)
-            zi = apex[2] - R * np.cos(inner)
-            ax.plot_surface(xi, yi, zi, color=color, alpha=alpha, linewidth=0)
-            p = np.linspace(inner, outer, 10)
-            P, RR = np.meshgrid(p, r)
-            for ang in [yaw_start, yaw_end]:
-                xs = apex[0] + RR * np.sin(P) * np.cos(ang)
-                ys = apex[1] + RR * np.sin(P) * np.sin(ang)
-                zs = apex[2] - RR * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
-            for rad in [r_min, r_max]:
-                P, TT = np.meshgrid(p, t)
-                xs = apex[0] + rad * np.sin(P) * np.cos(TT)
-                ys = apex[1] + rad * np.sin(P) * np.sin(TT)
-                zs = apex[2] - rad * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
-        else:
-            p = np.linspace(0, outer, 10)
-            P, RR = np.meshgrid(p, r)
-            for ang in [yaw_start, yaw_end]:
-                xs = apex[0] + RR * np.sin(P) * np.cos(ang)
-                ys = apex[1] + RR * np.sin(P) * np.sin(ang)
-                zs = apex[2] - RR * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
-            for rad in [r_max]:
-                P, TT = np.meshgrid(p, t)
-                xs = apex[0] + rad * np.sin(P) * np.cos(TT)
-                ys = apex[1] + rad * np.sin(P) * np.sin(TT)
-                zs = apex[2] - rad * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
+    # Surfaces that used to fill the volume were removed to reduce lag
+    # in interactive plots. Only the outline is drawn now so the spawn
+    # region remains visible without the heavy meshes.
 
 
 def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = None) -> None:

--- a/plot_config.py
+++ b/plot_config.py
@@ -67,51 +67,9 @@ def draw_spawn_volume(
                 z = apex[2] - np.array([r_min, r_max]) * np.cos(inner)
                 ax.plot(x, y, z, **line_kw)
 
-        # create smooth surfaces closing the wedge
-        t = np.linspace(yaw_start, yaw_end, 30)
-        r = np.linspace(r_min, r_max, 10)
-        T, R = np.meshgrid(t, r)
-        # outer cone surface
-        xo = apex[0] + R * np.sin(outer) * np.cos(T)
-        yo = apex[1] + R * np.sin(outer) * np.sin(T)
-        zo = apex[2] - R * np.cos(outer)
-        ax.plot_surface(xo, yo, zo, color=color, alpha=alpha, linewidth=0)
-        if inner > 0:
-            xi = apex[0] + R * np.sin(inner) * np.cos(T)
-            yi = apex[1] + R * np.sin(inner) * np.sin(T)
-            zi = apex[2] - R * np.cos(inner)
-            ax.plot_surface(xi, yi, zi, color=color, alpha=alpha, linewidth=0)
-            # surfaces closing the wedge sides
-            p = np.linspace(inner, outer, 10)
-            P, RR = np.meshgrid(p, r)
-            for ang in [yaw_start, yaw_end]:
-                xs = apex[0] + RR * np.sin(P) * np.cos(ang)
-                ys = apex[1] + RR * np.sin(P) * np.sin(ang)
-                zs = apex[2] - RR * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
-            # top and bottom surfaces of the truncated cone
-            for rad in [r_min, r_max]:
-                P, TT = np.meshgrid(p, t)
-                xs = apex[0] + rad * np.sin(P) * np.cos(TT)
-                ys = apex[1] + rad * np.sin(P) * np.sin(TT)
-                zs = apex[2] - rad * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
-        else:
-            # when inner == 0 just close the sides and bottom
-            p = np.linspace(0, outer, 10)
-            P, RR = np.meshgrid(p, r)
-            for ang in [yaw_start, yaw_end]:
-                xs = apex[0] + RR * np.sin(P) * np.cos(ang)
-                ys = apex[1] + RR * np.sin(P) * np.sin(ang)
-                zs = apex[2] - RR * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
-            # bottom surface
-            for rad in [r_max]:
-                P, TT = np.meshgrid(p, t)
-                xs = apex[0] + rad * np.sin(P) * np.cos(TT)
-                ys = apex[1] + rad * np.sin(P) * np.sin(TT)
-                zs = apex[2] - rad * np.cos(P)
-                ax.plot_surface(xs, ys, zs, color=color, alpha=alpha, linewidth=0)
+    # Surfaces used to fill the volume were removed to improve
+    # interactive performance. Only the outline lines are drawn now so the
+    # spawn area remains visible without the heavy translucent meshes.
 
 
 def main():


### PR DESCRIPTION
## Summary
- slim plotting functions by removing heavy surface meshes
- keep spawn volume outline for clarity
- update docs to mention this change

## Testing
- `python -m py_compile plot_config.py play.py`
- `flake8 plot_config.py play.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_6870499231d4833287d9fb0457e7948e