### PR TITLE
Add TensorBoard logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ The defaults for these options live in ``config.yaml`` under the
 It will print evaluation statistics every ``--eval-freq`` episodes and a final
 summary when training finishes.
 
+### Monitoring training with TensorBoard
+
+Both training scripts can write metrics for visualization with TensorBoard.
+Pass ``--log-dir`` to specify where logs should be stored. For example:
+
+```bash
+python train_pursuer.py --log-dir runs/reinforce
+```
+
+Start TensorBoard with
+
+```bash
+tensorboard --logdir runs
+```
+
+This will show episode rewards, evaluation results and losses during training.
+
 ### PPO variant
 
 For a more stable actor--critic approach, run the ``train_pursuer_ppo.py``

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch
 gymnasium
 matplotlib
 pyyaml
+tensorboard

--- a/train_pursuer.py
+++ b/train_pursuer.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
 import gymnasium as gym
 from typing import Optional
 
@@ -142,6 +143,7 @@ def train(
     *,
     checkpoint_every: int | None = None,
     resume_from: str | None = None,
+    log_dir: str | None = None,
 ):
     """Train the pursuer policy with REINFORCE.
 
@@ -156,6 +158,9 @@ def train(
         Save intermediate checkpoints every this many episodes when not ``None``.
     resume_from:
         Optional path to a checkpoint file to start from.
+    log_dir:
+        Optional directory for TensorBoard logs. When ``None`` no logging is
+        performed.
     """
 
     training_cfg = cfg.get('training', {})
@@ -168,6 +173,7 @@ def train(
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     env = PursuerOnlyEnv(cfg)
     policy = PursuerPolicy(env.observation_space.shape[0]).to(device)
+    writer = SummaryWriter(log_dir=log_dir) if log_dir else None
     if resume_from:
         state_dict = torch.load(resume_from, map_location=device)
         policy.load_state_dict(state_dict)
@@ -234,6 +240,20 @@ def train(
         for row in last_rows:
             print(row)
         episode_reward = sum(rewards)
+        if writer:
+            writer.add_scalar("train/episode_reward", episode_reward, episode)
+            if info:
+                writer.add_scalar(
+                    "train/min_distance",
+                    info.get("min_distance", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "train/episode_length",
+                    info.get("episode_steps", step),
+                    episode,
+                )
+            writer.add_scalar("train/loss", loss.item(), episode)
         if info:
             print(
                 f"Episode {episode+1}: reward={episode_reward:.2f} "
@@ -244,6 +264,9 @@ def train(
             # Periodically report progress on separate evaluation episodes
             avg_r, success = evaluate(policy, PursuerOnlyEnv(config))
             print(f"Episode {episode+1}: avg_reward={avg_r:.2f} success={success:.2f}")
+            if writer:
+                writer.add_scalar("eval/avg_reward", avg_r, episode)
+                writer.add_scalar("eval/success_rate", success, episode)
         if checkpoint_every and save_path and (episode + 1) % checkpoint_every == 0:
             base, ext = os.path.splitext(save_path)
             ckpt_path = f"{base}_ckpt_{episode+1}{ext}"
@@ -253,10 +276,15 @@ def train(
     # Final evaluation after training
     avg_r, success = evaluate(policy, PursuerOnlyEnv(config))
     print(f"Final performance: avg_reward={avg_r:.2f} success={success:.2f}")
+    if writer:
+        writer.add_scalar("eval/final_avg_reward", avg_r, num_episodes)
+        writer.add_scalar("eval/final_success_rate", success, num_episodes)
 
     if save_path is not None:
         torch.save(policy.state_dict(), save_path)
         print(f"Model saved to {save_path}")
+    if writer:
+        writer.close()
 
 
 if __name__ == "__main__":
@@ -282,6 +310,12 @@ if __name__ == "__main__":
         type=str,
         help="start training from this checkpoint file",
     )
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        default="runs/reinforce",
+        help="write TensorBoard logs to this directory",
+    )
     args = parser.parse_args()
 
     training_cfg = config.setdefault('training', {
@@ -306,4 +340,5 @@ if __name__ == "__main__":
         save_path=args.save_path,
         checkpoint_every=training_cfg.get('checkpoint_steps'),
         resume_from=args.resume_from,
+        log_dir=args.log_dir,
     )

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
 import gymnasium as gym
 from typing import Optional
 
@@ -153,8 +154,24 @@ def train(
     *,
     checkpoint_every: int | None = None,
     resume_from: str | None = None,
+    log_dir: str | None = None,
 ):
-    """Train the pursuer policy using PPO."""
+    """Train the pursuer policy using PPO.
+
+    Parameters
+    ----------
+    cfg:
+        Configuration dictionary with a ``training`` section.
+    save_path:
+        Path to store the final model parameters.
+    checkpoint_every:
+        Interval in episodes between checkpoints when set.
+    resume_from:
+        Optional checkpoint file to load before starting training.
+    log_dir:
+        Optional directory for TensorBoard logs. When ``None`` no logging is
+        performed.
+    """
 
     training_cfg = cfg.get('training', {})
     num_episodes = training_cfg.get('episodes', 100)
@@ -166,6 +183,7 @@ def train(
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     env = PursuerOnlyEnv(cfg)
     model = ActorCritic(env.observation_space.shape[0]).to(device)
+    writer = SummaryWriter(log_dir=log_dir) if log_dir else None
     if resume_from:
         state_dict = torch.load(resume_from, map_location=device)
         model.load_state_dict(state_dict)
@@ -251,6 +269,9 @@ def train(
             loss.backward()
             optimizer.step()
 
+        if writer:
+            writer.add_scalar("train/loss", loss.item(), episode)
+
         print(f"Initial pursuer pos: {init_pursuer_pos}")
         print(f"Initial evader pos: {init_evader_pos}")
         print(header)
@@ -260,6 +281,19 @@ def train(
         for row in last_rows:
             print(row)
         episode_reward = sum(rewards)
+        if writer:
+            writer.add_scalar("train/episode_reward", episode_reward, episode)
+            if info:
+                writer.add_scalar(
+                    "train/min_distance",
+                    info.get("min_distance", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "train/episode_length",
+                    info.get("episode_steps", step),
+                    episode,
+                )
         if info:
             print(
                 f"Episode {episode+1}: reward={episode_reward:.2f} "
@@ -272,6 +306,9 @@ def train(
             print(
                 f"Episode {episode+1}: avg_reward={avg_r:.2f} success={success:.2f}"
             )
+            if writer:
+                writer.add_scalar("eval/avg_reward", avg_r, episode)
+                writer.add_scalar("eval/success_rate", success, episode)
         if checkpoint_every and save_path and (episode + 1) % checkpoint_every == 0:
             base, ext = os.path.splitext(save_path)
             ckpt_path = f"{base}_ckpt_{episode+1}{ext}"
@@ -280,10 +317,15 @@ def train(
 
     avg_r, success = evaluate(model, PursuerOnlyEnv(cfg))
     print(f"Final performance: avg_reward={avg_r:.2f} success={success:.2f}")
+    if writer:
+        writer.add_scalar("eval/final_avg_reward", avg_r, num_episodes)
+        writer.add_scalar("eval/final_success_rate", success, num_episodes)
 
     if save_path is not None:
         torch.save(model.state_dict(), save_path)
         print(f"Model saved to {save_path}")
+    if writer:
+        writer.close()
 
 
 if __name__ == "__main__":
@@ -303,6 +345,12 @@ if __name__ == "__main__":
         "--resume-from",
         type=str,
         help="start training from this checkpoint file",
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        default="runs/ppo",
+        help="write TensorBoard logs to this directory",
     )
     args = parser.parse_args()
 
@@ -330,4 +378,5 @@ if __name__ == "__main__":
         save_path=args.save_path,
         checkpoint_every=training_cfg.get('checkpoint_steps'),
         resume_from=args.resume_from,
+        log_dir=args.log_dir,
     )


### PR DESCRIPTION
## Summary
- add TensorBoard to requirements
- implement logging with `SummaryWriter` in both training scripts
- allow configurable `--log-dir` for logging
- document logging usage in README

## Testing
- `python -m py_compile train_pursuer.py train_pursuer_ppo.py play.py pursuit_evasion.py plot_config.py`
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_687048f863e48332b4b2929d4400320a