### PR TITLE
Enable parallel environments for PPO training

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The command line options are the same as for ``train_pursuer.py`` and the
 trained weights are written to ``pursuer_ppo.pt`` unless ``--save-path`` is
 specified. Both training scripts also support ``--checkpoint-every`` to save
 periodic checkpoints and ``--resume-from`` to continue from a saved model.
+The PPO trainer additionally accepts ``--num-envs`` to run several
+environment instances in parallel which can significantly speed up data
+collection on multi-core machines.
 
 ## Additional scripts
 


### PR DESCRIPTION
## Summary
- support running multiple PursuerOnlyEnv instances in parallel using `gym.vector.AsyncVectorEnv`
- add `--num-envs` CLI option and document it
- update PPO training loop to gather batches from several environments

## Testing
- `python -m py_compile train_pursuer_ppo.py train_pursuer.py pursuit_evasion.py plot_config.py play.py sweep.py`


------
https://chatgpt.com/codex/tasks/task_e_6870f550a65883328101f7d25632fc3a