### PR TITLE
Update action to scalar acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ degrees but converted to radians when the environment loads. Actions
 specify yaw and **pitch** where pitch is measured relative to the horizontal
 x–y plane (positive values command an upward climb). Both agents clamp
 their pitch commands to ``[-stall_angle, +stall_angle]``. The first action
-component controls acceleration. The pursuer may command negative values
-down to ``-max_acceleration`` to brake. The
+component controls the **magnitude** of the acceleration while the yaw and
+pitch angles define its direction. Acceleration can slow the agent down but is
+clamped so that it never reverses the current velocity. The
 ``evader.trajectory`` option selects a preset flight profile. When set to
 ``"dive"`` the evader keeps a non-negative pitch until the line of sight to the
 target drops below ``evader.dive_angle`` (specified in degrees). Once past this

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,7 @@ pursuer:
   mass: 100.0
   # Maximum acceleration magnitude [m/s^2]
   max_acceleration: 30.0
-  # Acceleration can be negative allowing the pursuer to brake
+  # Commanded acceleration magnitude [non-negative]
   # Upper speed limit [m/s]
   top_speed: 150.0
   # Dimensionless coefficient modelling drag


### PR DESCRIPTION
## Summary
- make acceleration commands non-negative scalars
- prevent velocity reversal when decelerating
- clarify acceleration usage in README and config

## Testing
- `python -m py_compile pursuit_evasion.py play.py train_pursuer.py train_pursuer_ppo.py plot_config.py sweep.py`
- `python pursuit_evasion.py`

------
https://chatgpt.com/codex/tasks/task_e_6871534261c883328c5c2049d4f3cf73