### PR TITLE
Add configurable separation cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ which is useful for quickly checking that the environment works.
 The environment stores several statistics for each episode. When an episode
 finishes the ``info`` dictionary returned from ``env.step`` contains the
 closest pursuer--evader distance, number of steps and outcome (capture,
-evader reaching the target, separation exceeding twice the starting distance or timeout). The evaluation helpers in the training
+evader reaching the target, separation exceeding a multiple of the starting distance (controlled by `separation_cutoff_factor` in `config.yaml`) or timeout). The evaluation helpers in the training
 scripts print the average minimum distance and episode length during
 periodic evaluations.
 
@@ -161,7 +161,9 @@ Both `pursuit_evasion.py` and `train_pursuer.py` load the configuration
 at runtime, so changes take effect the next time you run the scripts.
 The reward shaping parameters `shaping_weight`, `closer_weight` and
 `angle_weight` can be adjusted here as well to encourage desired
-behaviour.
+behaviour. The `separation_cutoff_factor` option defines a multiplier of
+the initial pursuer--evader distance that ends the episode when the
+agents drift farther apart than this threshold.
 
 The `evader.awareness_mode` option defines how much information the
 evader receives about the pursuer:

--- a/config.yaml
+++ b/config.yaml
@@ -91,6 +91,11 @@ pursuer_start:
 # Percentage error applied to angular measurements of the opposing agent
 measurement_error_pct: 0.0
 
+# Factor multiplying the starting distance between the agents that
+# triggers episode termination when their separation exceeds this
+# multiple.
+separation_cutoff_factor: 2.0
+
 # Training related options
 training:
   # Number of training episodes

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -123,6 +123,8 @@ class PursuitEvasionEnv(gym.Env):
         # and the line of sight to the evader from one step to the next.
         self.angle_weight = self.cfg.get('angle_weight', 0.0)
         self.meas_err = self.cfg.get('measurement_error_pct', 0.0) / 100.0
+        # maximum allowed separation before the episode ends
+        self.cutoff_factor = self.cfg.get('separation_cutoff_factor', 2.0)
         # Convert stall angles provided in degrees to radians once
         self.cfg['evader']['stall_angle'] = np.deg2rad(
             self.cfg['evader']['stall_angle']
@@ -292,7 +294,7 @@ class PursuitEvasionEnv(gym.Env):
                 info['outcome'] = 'evader_ground'
             elif self.pursuer_pos[2] < 0.0:
                 info['outcome'] = 'pursuer_ground'
-            elif dist_pe >= 2 * self.start_pe_dist:
+            elif dist_pe >= self.cutoff_factor * self.start_pe_dist:
                 info['outcome'] = 'separation_exceeded'
 
         self.cur_step += 1
@@ -405,7 +407,7 @@ class PursuitEvasionEnv(gym.Env):
 
         if dist <= self.cfg['capture_radius']:
             return True, -1.0, 1.0
-        if dist >= 2 * self.start_pe_dist:
+        if dist >= self.cutoff_factor * self.start_pe_dist:
             return True, 0.0, 0.0
 
         # episode ends if either agent goes below ground level


### PR DESCRIPTION
## Summary
- expose `separation_cutoff_factor` in `config.yaml`
- explain new option in README
- end episodes using the configured cutoff in the environment

## Testing
- `python -m py_compile pursuit_evasion.py`

------
https://chatgpt.com/codex/tasks/task_e_68717fc2ad008332a52fd2a5931ec6d3