### PR TITLE
Implement yaw-range curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ The PPO trainer additionally accepts ``--num-envs`` to run several
 environment instances in parallel which can significantly speed up data
 collection on multi-core machines.
 
+### Curriculum training
+
+Both training scripts optionally support gradually increasing the starting
+difficulty of each episode. The `training.curriculum` section in
+`config.yaml` contains `start` and `end` dictionaries with values that are
+interpolated over the course of training. Any numeric field under these
+dictionaries will be linearly scaled from the `start` value to the `end`
+value as episodes progress. For example, the default configuration narrows
+the pursuer's `yaw_range` and initial `force_target_radius` to begin the
+agent immediately behind the evader before expanding to the full search
+area. The curriculum makes it possible to smoothly transition from simple
+encounters to more challenging ones.
+
 ## Additional scripts
 
 - `pursuit_evasion.py` contains the environment implementation along with a
@@ -150,13 +163,14 @@ the target (within ±15° of the exact bearing).
 The pursuer's starting position is sampled inside a configurable volume.
 `pursuer_start.cone_half_angle` sets the outer limit of the spawn cone
 below the evader while `pursuer_start.inner_cone_half_angle` specifies an
-inner cutoff to avoid very steep spawn angles.  The `sections` dictionary
-divides the horizontal plane around the evader into four 90° quadrants
-(`front`, `right`, `back`, `left`) relative to the evader's initial
-heading.  Each section can be enabled or disabled to further restrict the
-spawn volume.  Combined with the `min_range` and `max_range` distances
-these options define where the pursuer may appear at the beginning of an
-episode.
+inner cutoff to avoid very steep spawn angles.  Horizontal placement can be
+controlled either by specifying explicit `sections` (front, right, back and
+left quadrants) **or** with `pursuer_start.yaw_range`.  The yaw range is
+measured relative to directly behind the evader (0&nbsp;rad points toward the
+pursuer approaching from behind).  When `yaw_range` is present it overrides
+the section based spawning.  Combined with the `min_range` and
+`max_range` distances these options define where the pursuer may appear at
+the beginning of an episode.
 Both `pursuit_evasion.py` and `train_pursuer.py` load the configuration
 at runtime, so changes take effect the next time you run the scripts.
 The reward shaping parameters `shaping_weight`, `closer_weight` and

--- a/config.yaml
+++ b/config.yaml
@@ -74,12 +74,9 @@ pursuer_start:
   cone_half_angle: 1.5
   # Minimum half angle of the pursuer spawn cone [rad]
   inner_cone_half_angle: 1.3
-  # Enable or disable spawn quadrants relative to the evader heading
-  sections:
-    front: false
-    left: true
-    right: true
-    back: false
+  # Horizontal angular range relative to directly behind the evader [rad]
+  # When set this overrides the ``sections`` breakdown into quadrants.
+  yaw_range: [-3.14159, 3.14159]
   # Minimum initial range from the evader [m]
   min_range: 1000.0
   # Maximum initial range from the evader [m]
@@ -113,3 +110,29 @@ training:
   eval_freq: 1000
   # Save a checkpoint every this many episodes. Set to 0 to disable.
   checkpoint_steps: 0
+  # Curriculum specifying how the starting conditions gradually expand
+  # throughout training. The ``start`` dictionary defines the easiest
+  # configuration while ``end`` corresponds to the final environment
+  # parameters. All numeric values are linearly interpolated from the
+  # beginning to the end of training.
+  curriculum:
+    start:
+      evader_start:
+        distance_range: [10000.0, 10000.0]
+      pursuer_start:
+        cone_half_angle: 0.0
+        inner_cone_half_angle: 0.0
+        min_range: 1000.0
+        max_range: 1000.0
+        yaw_range: [0.0, 0.0]
+        force_target_radius: 0.0
+    end:
+      evader_start:
+        distance_range: [8000.0, 12000.0]
+      pursuer_start:
+        cone_half_angle: 1.5
+        inner_cone_half_angle: 1.3
+        min_range: 1000.0
+        max_range: 5000.0
+        yaw_range: [-3.14159, 3.14159]
+        force_target_radius: 150.0

--- a/play.py
+++ b/play.py
@@ -152,15 +152,19 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = 
     )
     deg45 = np.deg2rad(45.0)
     base_yaw = np.arctan2(heading_dir[1], heading_dir[0])
-    ranges = []
-    if sections.get("front", True):
-        ranges.append((base_yaw - deg45, base_yaw + deg45))
-    if sections.get("right", True):
-        ranges.append((base_yaw - np.pi / 2 - deg45, base_yaw - np.pi / 2 + deg45))
-    if sections.get("back", True):
-        ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
-    if sections.get("left", True):
-        ranges.append((base_yaw + deg45, base_yaw + np.pi / 2 + deg45))
+    if "yaw_range" in p_cfg:
+        yaw_min, yaw_max = p_cfg["yaw_range"]
+        ranges = [(base_yaw + np.pi + yaw_min, base_yaw + np.pi + yaw_max)]
+    else:
+        ranges = []
+        if sections.get("front", True):
+            ranges.append((base_yaw - deg45, base_yaw + deg45))
+        if sections.get("right", True):
+            ranges.append((base_yaw - np.pi / 2 - deg45, base_yaw - np.pi / 2 + deg45))
+        if sections.get("back", True):
+            ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
+        if sections.get("left", True):
+            ranges.append((base_yaw + deg45, base_yaw + np.pi / 2 + deg45))
     draw_spawn_volume(
         ax,
         e_start_pos,

--- a/plot_config.py
+++ b/plot_config.py
@@ -116,15 +116,19 @@ def main():
     heading[2] = 0.0
     base_yaw = np.arctan2(heading[1], heading[0])
     deg45 = np.deg2rad(45.0)
-    ranges = []
-    if sections.get("front", True):
-        ranges.append((base_yaw - deg45, base_yaw + deg45))
-    if sections.get("right", True):
-        ranges.append((base_yaw - np.pi/2 - deg45, base_yaw - np.pi/2 + deg45))
-    if sections.get("back", True):
-        ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
-    if sections.get("left", True):
-        ranges.append((base_yaw + deg45, base_yaw + np.pi/2 + deg45))
+    if "yaw_range" in p_cfg:
+        yaw_min, yaw_max = p_cfg["yaw_range"]
+        ranges = [(base_yaw + np.pi + yaw_min, base_yaw + np.pi + yaw_max)]
+    else:
+        ranges = []
+        if sections.get("front", True):
+            ranges.append((base_yaw - deg45, base_yaw + deg45))
+        if sections.get("right", True):
+            ranges.append((base_yaw - np.pi/2 - deg45, base_yaw - np.pi/2 + deg45))
+        if sections.get("back", True):
+            ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
+        if sections.get("left", True):
+            ranges.append((base_yaw + deg45, base_yaw + np.pi/2 + deg45))
 
     draw_spawn_volume(
         ax,

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -29,6 +29,40 @@ def load_config(path: str | None = None) -> dict:
 config = load_config()
 
 
+def _interpolate(start: float, end: float, progress: float) -> float:
+    """Linear interpolation helper."""
+    return start + (end - start) * progress
+
+
+def apply_curriculum(cfg: dict, start_cfg: dict, end_cfg: dict, progress: float) -> None:
+    """Recursively interpolate ``cfg`` between ``start_cfg`` and ``end_cfg``.
+
+    Only keys present in ``start_cfg`` and ``end_cfg`` are touched. Numeric
+    values are interpolated linearly while boolean values switch from the start
+    to the end setting halfway through the training run.
+    """
+
+    for key, start_val in start_cfg.items():
+        if key not in end_cfg or key not in cfg:
+            continue
+        end_val = end_cfg[key]
+        if isinstance(start_val, dict) and isinstance(end_val, dict):
+            apply_curriculum(cfg[key], start_val, end_val, progress)
+        elif isinstance(start_val, (int, float)) and isinstance(end_val, (int, float)):
+            cfg[key] = _interpolate(float(start_val), float(end_val), progress)
+        elif (
+            isinstance(start_val, (list, tuple))
+            and isinstance(end_val, (list, tuple))
+            and len(start_val) == len(end_val)
+        ):
+            cfg[key] = [
+                _interpolate(float(s), float(e), progress)
+                for s, e in zip(start_val, end_val)
+            ]
+        elif isinstance(start_val, bool) and isinstance(end_val, bool):
+            cfg[key] = end_val if progress >= 0.5 else start_val
+
+
 def sample_pursuer_start(evader_pos: np.ndarray, heading: np.ndarray, cfg: dict):
     """Sample initial pursuer state and force direction.
 
@@ -41,26 +75,31 @@ def sample_pursuer_start(evader_pos: np.ndarray, heading: np.ndarray, cfg: dict)
     inner = params.get("inner_cone_half_angle", 0.0)
     r = np.random.uniform(params["min_range"], params["max_range"])
 
-    # choose a spawn quadrant relative to the evader heading
     base_yaw = np.arctan2(heading[1], heading[0])
-    sections_cfg = params.get(
-        "sections",
-        {"front": True, "left": True, "right": True, "back": True},
-    )
-    quadrants = []
-    deg45 = np.deg2rad(45.0)
-    if sections_cfg.get("front", True):
-        quadrants.append((-deg45, deg45))
-    if sections_cfg.get("right", True):
-        quadrants.append((-deg45 - np.pi / 2, deg45 - np.pi / 2))
-    if sections_cfg.get("back", True):
-        quadrants.append((np.pi - deg45, np.pi + deg45))
-    if sections_cfg.get("left", True):
-        quadrants.append((deg45, deg45 + np.pi / 2))
-    if not quadrants:
-        raise ValueError("No pursuer spawn sections enabled")
-    yaw_rel = np.random.uniform(*quadrants[np.random.randint(len(quadrants))])
-    yaw = (base_yaw + yaw_rel) % (2 * np.pi)
+    if "yaw_range" in params:
+        # Angular range is measured relative to directly behind the evader.
+        yaw_min, yaw_max = params["yaw_range"]
+        yaw_rel = np.random.uniform(yaw_min, yaw_max)
+        yaw = (base_yaw + np.pi + yaw_rel) % (2 * np.pi)
+    else:
+        sections_cfg = params.get(
+            "sections",
+            {"front": True, "left": True, "right": True, "back": True},
+        )
+        quadrants = []
+        deg45 = np.deg2rad(45.0)
+        if sections_cfg.get("front", True):
+            quadrants.append((-deg45, deg45))
+        if sections_cfg.get("right", True):
+            quadrants.append((-deg45 - np.pi / 2, deg45 - np.pi / 2))
+        if sections_cfg.get("back", True):
+            quadrants.append((np.pi - deg45, np.pi + deg45))
+        if sections_cfg.get("left", True):
+            quadrants.append((deg45, deg45 + np.pi / 2))
+        if not quadrants:
+            raise ValueError("No pursuer spawn sections enabled")
+        yaw_rel = np.random.uniform(*quadrants[np.random.randint(len(quadrants))])
+        yaw = (base_yaw + yaw_rel) % (2 * np.pi)
 
     pitch = np.random.uniform(inner, outer)
     # direction from the evader to the pursuer in world coordinates


### PR DESCRIPTION
## Summary
- replace spawn quadrant selection with angular `yaw_range`
- integrate yaw_range and force_target_radius in curriculum config
- adapt environment, plotting and playback utilities
- document curriculum schedule and yaw_range in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68717b5bf7ec8332bad2cb6983760280