### PR TITLE
Add log-dir checkpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ tensorboard --logdir runs
 ```
 
 This will show episode rewards, evaluation results and losses during training.
+When a log directory is set, periodic checkpoints created with
+``--checkpoint-every`` are stored under ``<log-dir>/checkpoints``.
 
 ### New training options
 
@@ -100,6 +102,7 @@ The command line options are the same as for ``train_pursuer.py`` and the
 trained weights are written to ``pursuer_ppo.pt`` unless ``--save-path`` is
 specified. Both training scripts also support ``--checkpoint-every`` to save
 periodic checkpoints and ``--resume-from`` to continue from a saved model.
+If ``--log-dir`` is supplied these checkpoints are placed in ``<log-dir>/checkpoints``.
 The PPO trainer additionally accepts ``--num-envs`` to run several
 environment instances in parallel which can significantly speed up data
 collection on multi-core machines.

--- a/train_pursuer.py
+++ b/train_pursuer.py
@@ -340,8 +340,14 @@ def train(
                     writer.add_scalar("sweep/episodes_to_reward", episode + 1, 0)
                     efficiency_logged = True
         if checkpoint_every and save_path and (episode + 1) % checkpoint_every == 0:
-            base, ext = os.path.splitext(save_path)
-            ckpt_path = f"{base}_ckpt_{episode+1}{ext}"
+            base_name, ext = os.path.splitext(os.path.basename(save_path))
+            ckpt_file = f"{base_name}_ckpt_{episode+1}{ext}"
+            if log_dir:
+                ckpt_dir = os.path.join(log_dir, "checkpoints")
+                os.makedirs(ckpt_dir, exist_ok=True)
+                ckpt_path = os.path.join(ckpt_dir, ckpt_file)
+            else:
+                ckpt_path = os.path.join(os.path.dirname(save_path), ckpt_file)
             torch.save(policy.state_dict(), ckpt_path)
             print(f"Checkpoint saved to {ckpt_path}")
 

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -453,8 +453,14 @@ def train(
                     writer.add_scalar("sweep/episodes_to_reward", episode + 1, 0)
                     efficiency_logged = True
         if checkpoint_every and save_path and (episode + 1) % checkpoint_every == 0:
-            base, ext = os.path.splitext(save_path)
-            ckpt_path = f"{base}_ckpt_{episode+1}{ext}"
+            base_name, ext = os.path.splitext(os.path.basename(save_path))
+            ckpt_file = f"{base_name}_ckpt_{episode+1}{ext}"
+            if log_dir:
+                ckpt_dir = os.path.join(log_dir, "checkpoints")
+                os.makedirs(ckpt_dir, exist_ok=True)
+                ckpt_path = os.path.join(ckpt_dir, ckpt_file)
+            else:
+                ckpt_path = os.path.join(os.path.dirname(save_path), ckpt_file)
             torch.save(model.state_dict(), ckpt_path)
             print(f"Checkpoint saved to {ckpt_path}")
 


### PR DESCRIPTION
## Summary
- store checkpoints under `<log-dir>/checkpoints` when a log directory is provided
- document new checkpoint location in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871921b5fe08332a3b2575727f4de49