### PR TITLE
Add pursuer time penalty

### DIFF
--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -278,6 +278,9 @@ class PursuitEvasionEnv(gym.Env):
     def step(self, action: dict):
         """Update the environment one time step.
 
+        A small time penalty of ``-0.001`` is applied to the pursuer's
+        reward on every step to encourage faster capture.
+
         Parameters
         ----------
         action : dict
@@ -318,6 +321,8 @@ class PursuitEvasionEnv(gym.Env):
         r_p += self.shaping_weight * shape_p
         r_p += closer_bonus
         r_p += angle_bonus
+        # small time penalty encouraging quick capture
+        r_p -= 0.001
         obs = self._get_obs()
         reward = {'evader': r_e, 'pursuer': r_p}
         info = {}


### PR DESCRIPTION
## Summary
- encourage quicker pursuer captures by subtracting a small time penalty each step

## Testing
- `python -m py_compile pursuit_evasion.py`


------
https://chatgpt.com/codex/tasks/task_e_68719e24fc208332990c0c741b21c229