### PR TITLE
Add evader success check

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ which is useful for quickly checking that the environment works.
 The environment stores several statistics for each episode. When an episode
 finishes the ``info`` dictionary returned from ``env.step`` contains the
 closest pursuer--evader distance, number of steps and outcome (capture,
-evader reaching the target, separation exceeding a multiple of the starting distance (controlled by `separation_cutoff_factor` in `config.yaml`) or timeout). The evaluation helpers in the training
+evader reaching the target while airborne, separation exceeding a multiple of the starting distance (controlled by `separation_cutoff_factor` in `config.yaml`) or timeout). The evaluation helpers in the training
 scripts print the average minimum distance and episode length during
 periodic evaluations.
 
@@ -209,7 +209,9 @@ When either agent touches the ground the episode terminates. If the evader
 hits the ground its terminal reward scales with the distance to the target
 using ``target_reward_distance``. A reward of one is given when it reaches the
 goal and it falls off to zero once the evader is roughly 100&nbsp;m away by
-default.
+default. Episodes also end successfully when the airborne evader comes within
+100&nbsp;m of the goal. The radius for this check can be adjusted via the
+``target_success_distance`` setting.
 
 ## Sensor error model
 

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -293,6 +293,8 @@ class PursuitEvasionEnv(gym.Env):
         dist_pe = np.linalg.norm(self.evader_pos - self.pursuer_pos)
         target = np.array(self.cfg['target_position'], dtype=np.float32)
         dist_target = np.linalg.norm(self.evader_pos - target)
+        dist_target_xy = np.linalg.norm((self.evader_pos - target)[:2])
+        success_thresh = self.cfg.get('target_success_distance', 100.0)
         self.min_pe_dist = min(self.min_pe_dist, dist_pe)
         shape_p = self.prev_pe_dist - dist_pe
         shape_e = self.prev_target_dist - dist_target
@@ -331,6 +333,8 @@ class PursuitEvasionEnv(gym.Env):
             }
             if dist_pe <= self.cfg['capture_radius']:
                 info['outcome'] = 'capture'
+            elif dist_target_xy <= success_thresh and self.evader_pos[2] > 0.0:
+                info['outcome'] = 'evader_success'
             elif self.evader_pos[2] < 0.0:
                 info['outcome'] = 'evader_ground'
             elif self.pursuer_pos[2] < 0.0:
@@ -453,13 +457,22 @@ class PursuitEvasionEnv(gym.Env):
         return pos_obs.astype(np.float32), vel_obs.astype(np.float32)
 
     def _check_done(self):
-        """Determine if the episode has terminated."""
+        """Determine if the episode has terminated.
+
+        Episodes end on capture, excessive separation, either agent touching
+        the ground or the evader reaching the vicinity of its target while
+        still airborne.
+        """
         dist = np.linalg.norm(self.evader_pos - self.pursuer_pos)
         target = np.array(self.cfg['target_position'], dtype=np.float32)
         dist_target = np.linalg.norm(self.evader_pos - target)
+        dist_target_xy = np.linalg.norm((self.evader_pos - target)[:2])
+        success_thresh = self.cfg.get('target_success_distance', 100.0)
 
         if dist <= self.cfg['capture_radius']:
             return True, -1.0, 1.0
+        if dist_target_xy <= success_thresh and self.evader_pos[2] > 0.0:
+            return True, 1.0, 0.0
         if dist >= self.cutoff_factor * self.start_pe_dist:
             return True, 0.0, 0.0
 


### PR DESCRIPTION
## Summary
- stop episode when evader flies within 100m of the goal
- log new `evader_success` outcome
- document new behaviour in the README

## Testing
- `python pursuit_evasion.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68719e5678388332bf6cc0a564484cc1