### PR TITLE
Add evader speed curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ interpolated over the course of training. Any numeric field under these
 dictionaries will be linearly scaled from the `start` value to the `end`
 value as episodes progress. For example, the default configuration narrows
 the pursuer's `yaw_range` and initial `force_target_radius` to begin the
-agent immediately behind the evader before expanding to the full search
+agent immediately behind the evader while increasing `evader_start.initial_speed`
+from 0&nbsp;m/s to 50&nbsp;m/s before expanding to the full search
 area. The curriculum makes it possible to smoothly transition from simple
 encounters to more challenging ones.
 

--- a/config.yaml
+++ b/config.yaml
@@ -124,6 +124,7 @@ training:
     start:
       evader_start:
         distance_range: [10000.0, 10000.0]
+        initial_speed: 0.0
       pursuer_start:
         cone_half_angle: 0.0
         inner_cone_half_angle: 0.0
@@ -134,6 +135,7 @@ training:
     end:
       evader_start:
         distance_range: [8000.0, 12000.0]
+        initial_speed: 50.0
       pursuer_start:
         cone_half_angle: 1.5
         inner_cone_half_angle: 1.3


### PR DESCRIPTION
## Summary
- expand curriculum config to progressively raise the evader's starting speed from 0 to 50 m/s
- mention the speed ramp in the README documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719f1535b083328eaf1da0f8abd66a