### PR TITLE
Expose PPO hyperparameters via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,12 @@ periodic checkpoints and ``--resume-from`` to continue from a saved model.
 If ``--log-dir`` is supplied these checkpoints are placed in ``<log-dir>/checkpoints``.
 The PPO trainer additionally accepts ``--num-envs`` to run several
 environment instances in parallel which can significantly speed up data
-collection on multi-core machines.
+collection on multi-core machines. All algorithm parameters
+(``gamma``, ``clip_ratio``, ``ppo_epochs`` and the entropy bonus weight)
+live in the ``training`` section of ``config.yaml`` and may be overridden
+via command line flags. The entropy bonus coefficient decays linearly
+from ``entropy_coef_start`` to ``entropy_coef_end`` over the course of
+training.
 
 ### Curriculum training
 

--- a/config.yaml
+++ b/config.yaml
@@ -119,6 +119,16 @@ training:
   eval_freq: 1000
   # Save a checkpoint every this many episodes. Set to 0 to disable.
   checkpoint_steps: 0
+  # Discount factor for return calculations
+  gamma: 0.99
+  # PPO clipping ratio
+  clip_ratio: 0.2
+  # Number of optimisation passes over each batch
+  ppo_epochs: 4
+  # Entropy bonus coefficient. The value decays linearly from
+  # ``entropy_coef_start`` to ``entropy_coef_end`` over training.
+  entropy_coef_start: 0.01
+  entropy_coef_end: 0.01
   # Curriculum specifying how the starting conditions gradually expand
   # throughout training. The ``start`` dictionary defines the easiest
   # configuration while ``end`` corresponds to the final environment

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -265,10 +265,11 @@ def train(
         else None
     )
 
-    gamma = 0.99
-    clip_ratio = 0.2
-    ppo_epochs = 4
-    entropy_coef = 0.01
+    gamma = training_cfg.get('gamma', 0.99)
+    clip_ratio = training_cfg.get('clip_ratio', 0.2)
+    ppo_epochs = training_cfg.get('ppo_epochs', 4)
+    entropy_start = training_cfg.get('entropy_coef_start', 0.01)
+    entropy_end = training_cfg.get('entropy_coef_end', entropy_start)
 
     header = (
         f"{'step':>5} | {'pursuer→evader [m]':>26} | "
@@ -281,6 +282,7 @@ def train(
 
     for episode in range(num_episodes):
         progress = episode / max(num_episodes - 1, 1)
+        entropy_coef = entropy_start + (entropy_end - entropy_start) * progress
         if start_cur and end_cur:
             if num_envs == 1:
                 apply_curriculum(env.env.cfg, start_cur, end_cur, progress)
@@ -412,6 +414,7 @@ def train(
 
         if writer:
             writer.add_scalar("train/loss", loss.item(), episode)
+            writer.add_scalar("train/entropy_coef", entropy_coef, episode)
 
         if num_envs == 1:
             print(f"Initial pursuer pos: {init_pursuer_pos}")
@@ -561,6 +564,21 @@ if __name__ == "__main__":
         default=1,
         help="number of parallel environments",
     )
+    parser.add_argument("--gamma", type=float, help="discount factor")
+    parser.add_argument("--clip-ratio", type=float, help="PPO clipping ratio")
+    parser.add_argument(
+        "--ppo-epochs", type=int, help="number of optimisation epochs per batch"
+    )
+    parser.add_argument(
+        "--entropy-coef-start",
+        type=float,
+        help="initial entropy bonus weight",
+    )
+    parser.add_argument(
+        "--entropy-coef-end",
+        type=float,
+        help="final entropy bonus weight",
+    )
     args = parser.parse_args()
 
     training_cfg = config.setdefault(
@@ -575,6 +593,11 @@ if __name__ == "__main__":
             'reward_threshold': 0.0,
             'eval_freq': 1000,
             'checkpoint_steps': 0,
+            'gamma': 0.99,
+            'clip_ratio': 0.2,
+            'ppo_epochs': 4,
+            'entropy_coef_start': 0.01,
+            'entropy_coef_end': 0.01,
         },
     )
     if args.episodes is not None:
@@ -597,6 +620,16 @@ if __name__ == "__main__":
         training_cfg['eval_freq'] = args.eval_freq
     if args.checkpoint_every is not None:
         training_cfg['checkpoint_steps'] = args.checkpoint_every
+    if args.gamma is not None:
+        training_cfg['gamma'] = args.gamma
+    if args.clip_ratio is not None:
+        training_cfg['clip_ratio'] = args.clip_ratio
+    if args.ppo_epochs is not None:
+        training_cfg['ppo_epochs'] = args.ppo_epochs
+    if args.entropy_coef_start is not None:
+        training_cfg['entropy_coef_start'] = args.entropy_coef_start
+    if args.entropy_coef_end is not None:
+        training_cfg['entropy_coef_end'] = args.entropy_coef_end
     if args.time_step is not None:
         config['time_step'] = args.time_step
 


### PR DESCRIPTION
## Summary
- add PPO algorithm parameters to config.yaml
- control entropy bonus decay from start to end values
- allow overriding PPO hyperparams via CLI
- document new options in README

## Testing
- `python -m py_compile train_pursuer_ppo.py train_pursuer.py pursuit_evasion.py play.py plot_config.py sweep.py`
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6871addabaf08332bba65532b9fb3226