### PR TITLE
Add trainable log_std in ActorCritic

### DIFF
--- a/play.py
+++ b/play.py
@@ -99,9 +99,11 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = 
             obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
             if use_ppo:
                 mean, _ = model(obs_t)
+                std = model.std.expand_as(mean)
             else:
                 mean = model(obs_t)
-            dist = torch.distributions.Normal(mean, torch.ones_like(mean))
+                std = torch.ones_like(mean)
+            dist = torch.distributions.Normal(mean, std)
             action = dist.mean
         obs, r, done, _, info = env.step(action.cpu().numpy())
         pursuer_traj.append(env.env.pursuer_pos.copy())

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -152,11 +152,19 @@ class ActorCritic(nn.Module):
         super().__init__()
         self.policy_net = _make_mlp(obs_dim, 3, hidden_size, activation)
         self.value_net = _make_mlp(obs_dim, 1, hidden_size, activation)
+        # Log standard deviation for the Gaussian policy. Using ``zeros``
+        # initialisation mirrors the previous unit variance behaviour.
+        self.log_std = nn.Parameter(torch.zeros(3))
 
     def forward(self, obs: torch.Tensor):
         mean = self.policy_net(obs)
         value = self.value_net(obs).squeeze(-1)
         return mean, value
+
+    @property
+    def std(self) -> torch.Tensor:
+        """Return the action standard deviation."""
+        return self.log_std.exp()
 
 
 def evaluate(model: ActorCritic, env: PursuerOnlyEnv, episodes: int = 5):
@@ -173,7 +181,8 @@ def evaluate(model: ActorCritic, env: PursuerOnlyEnv, episodes: int = 5):
             with torch.no_grad():
                 obs_t = torch.tensor(obs, device=next(model.parameters()).device)
                 mean, _ = model(obs_t)
-                dist = torch.distributions.Normal(mean, torch.ones_like(mean))
+                std = model.std.expand_as(mean)
+                dist = torch.distributions.Normal(mean, std)
                 action = dist.mean
             obs, r, done, _, info = env.step(action.cpu().numpy())
             total += r
@@ -307,7 +316,8 @@ def train(
             while not done:
                 obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
                 mean, value = model(obs_t)
-                dist = torch.distributions.Normal(mean, torch.ones_like(mean))
+                std = model.std.expand_as(mean)
+                dist = torch.distributions.Normal(mean, std)
                 action = dist.sample()
                 log_prob = dist.log_prob(action).sum()
                 next_obs, r, done, _, info = env.step(action.cpu().numpy())
@@ -356,7 +366,8 @@ def train(
             while not np.all(done):
                 obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
                 mean, value = model(obs_t)
-                dist = torch.distributions.Normal(mean, torch.ones_like(mean))
+                std = model.std.expand_as(mean)
+                dist = torch.distributions.Normal(mean, std)
                 action = dist.sample()
                 log_prob = dist.log_prob(action).sum(dim=1)
                 next_obs, r, d, _, info = env.step(action.cpu().numpy())
@@ -402,7 +413,8 @@ def train(
 
         for _ in range(ppo_epochs):
             mean, value = model(obs_batch)
-            dist = torch.distributions.Normal(mean, torch.ones_like(mean))
+            std = model.std.expand_as(mean)
+            dist = torch.distributions.Normal(mean, std)
             log_probs_new = dist.log_prob(action_batch).sum(dim=1)
             entropy = dist.entropy().sum(dim=1)
             ratio = torch.exp(log_probs_new - old_log_probs)


### PR DESCRIPTION
## Summary
- allow ActorCritic to learn action variance via a `log_std` parameter
- create Normal distributions with the learned std during PPO training and evaluation
- use the learned std when playing saved models

## Testing
- `python -m py_compile train_pursuer_ppo.py play.py pursuit_evasion.py train_pursuer.py`
- `pip install numpy torch gymnasium matplotlib pyyaml tensorboard`
- `python train_pursuer_ppo.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6871ad55785483328c02057b1d227e3e