### PR TITLE
Add adaptive curriculum training mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ agent immediately behind the evader before expanding to the full search
 area. The curriculum makes it possible to smoothly transition from simple
 encounters to more challenging ones.
 
+When `training.curriculum_mode` is set to `adaptive` the scripts track the
+rolling success rate of evaluation episodes. The pursuer spawn parameters are
+only expanded to the next curriculum stage once the average success exceeds
+`training.curriculum_success_threshold`. This allows the policy to focus on the
+current difficulty until it reliably solves it before moving on.
+
 ## Additional scripts
 
 - `pursuit_evasion.py` contains the environment implementation along with a

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ The PPO trainer additionally accepts ``--num-envs`` to run several
 environment instances in parallel which can significantly speed up data
 collection on multi-core machines.
 
+### Curriculum training
+
+Both training scripts optionally support gradually increasing the starting
+difficulty of each episode. The `training.curriculum` section in
+`config.yaml` contains `start` and `end` dictionaries with values that are
+interpolated over the course of training. Any numeric field under these
+dictionaries will be linearly scaled from the `start` value to the `end`
+value as episodes progress. For example, the default configuration narrows
+the pursuer's `yaw_range` and initial `force_target_radius` to begin the
+agent immediately behind the evader before expanding to the full search
+area. The curriculum makes it possible to smoothly transition from simple
+encounters to more challenging ones.
+
 ## Additional scripts
 
 - `pursuit_evasion.py` contains the environment implementation along with a
@@ -150,13 +163,14 @@ the target (within ±15° of the exact bearing).
 The pursuer's starting position is sampled inside a configurable volume.
 `pursuer_start.cone_half_angle` sets the outer limit of the spawn cone
 below the evader while `pursuer_start.inner_cone_half_angle` specifies an
-inner cutoff to avoid very steep spawn angles.  The `sections` dictionary
-divides the horizontal plane around the evader into four 90° quadrants
-(`front`, `right`, `back`, `left`) relative to the evader's initial
-heading.  Each section can be enabled or disabled to further restrict the
-spawn volume.  Combined with the `min_range` and `max_range` distances
-these options define where the pursuer may appear at the beginning of an
-episode.
+inner cutoff to avoid very steep spawn angles.  Horizontal placement can be
+controlled either by specifying explicit `sections` (front, right, back and
+left quadrants) **or** with `pursuer_start.yaw_range`.  The yaw range is
+measured relative to directly behind the evader (0&nbsp;rad points toward the
+pursuer approaching from behind).  When `yaw_range` is present it overrides
+the section based spawning.  Combined with the `min_range` and
+`max_range` distances these options define where the pursuer may appear at
+the beginning of an episode.
 Both `pursuit_evasion.py` and `train_pursuer.py` load the configuration
 at runtime, so changes take effect the next time you run the scripts.
 The reward shaping parameters `shaping_weight`, `closer_weight` and

--- a/config.yaml
+++ b/config.yaml
@@ -17,8 +17,6 @@ evader:
   yaw_rate: 5
   # Maximum pitch rotation rate [deg/s]
   pitch_rate: 10
-  # Initial force direction
-  up_vector: [0.0, 0.0, 1.0]
   # Maximum allowable pitch angle [deg]
   stall_angle: 45.0
   # Preset trajectory mode. Use "dive" to level off until the dive angle
@@ -40,8 +38,6 @@ pursuer:
   yaw_rate: 20.0
   # Maximum pitch rotation rate [deg/s]
   pitch_rate: 25.0
-  # Initial force direction
-  up_vector: [0.0, 0.0, 1.0]
   # Maximum allowable pitch angle [deg]
   stall_angle: 55.0
 # Downward gravitational acceleration [m/s^2]
@@ -57,9 +53,15 @@ target_reward_distance: 100.0
 # Weight for shaping rewards
 shaping_weight: 0.05
 # Additional reward weight for simply getting closer to the evader each step
-closer_weight: 0.05
+closer_weight: 0.1
 # Additional reward weight for reducing the pursuer-to-evader angle
-angle_weight: 0.0
+angle_weight: 0.05
+# Additional reward weight for aligning the pursuer and evader headings
+heading_weight: 0.0
+# Extra reward multiplier for capturing before the time limit. The pursuer
+# receives ``1 + capture_bonus * (max_steps - episode_steps)`` when a capture
+# occurs, allowing earlier interceptions to yield higher returns.
+capture_bonus: 0.0
 # Coordinates of the evader's goal [m]
 target_position: [0, 0.0, 0.0]
 evader_start:
@@ -91,12 +93,12 @@ measurement_error_pct: 0.0
 # Factor multiplying the starting distance between the agents that
 # triggers episode termination when their separation exceeds this
 # multiple.
-separation_cutoff_factor: 2.0
+separation_cutoff_factor: 4.0
 
 # Training related options
 training:
   # Number of training episodes
-  episodes: 5000
+  episodes: 100000
   # Optimiser learning rate
   learning_rate: 0.001
   # L2 weight decay applied by the optimiser
@@ -104,7 +106,7 @@ training:
   # StepLR schedule - set step size to 0 to disable
   lr_step_size: 0
   # Multiplicative factor of learning rate decay
-  lr_gamma: 0.95
+  lr_gamma: 0.995
   # Width of hidden layers in the policy networks
   hidden_size: 64
   # Activation function: relu | tanh | leaky_relu
@@ -112,17 +114,19 @@ training:
   # Reward threshold for sample efficiency metric
   reward_threshold: 0.0
   # Run evaluation episodes every this many training episodes
-  eval_freq: 1000
+  eval_freq: 20000
   # Save a checkpoint every this many episodes. Set to 0 to disable.
-  checkpoint_steps: 0
+  checkpoint_steps: 2000
   # Curriculum progression mode: linear | adaptive
   curriculum_mode: linear
   # Rolling success threshold for adaptive curriculum
   curriculum_success_threshold: 0.8
   # Number of evaluation results to average for adaptive curriculum
   curriculum_window: 5
-  # Number of discrete curriculum stages
-  curriculum_stages: 5
+  # Number of discrete curriculum stages including the final environment.
+  # If set to ``N`` there will be ``N - 1`` transitions from ``curriculum.start``
+  # to ``curriculum.end`` over the course of training.
+  curriculum_stages: 2
   # Curriculum specifying how the starting conditions gradually expand
   # throughout training. The ``start`` dictionary defines the easiest
   # configuration while ``end`` corresponds to the final environment
@@ -132,9 +136,10 @@ training:
     start:
       evader_start:
         distance_range: [10000.0, 10000.0]
+        initial_speed: 0.0
       pursuer_start:
-        cone_half_angle: 0.0
-        inner_cone_half_angle: 0.0
+        cone_half_angle: 1.5708  
+        inner_cone_half_angle: 1.5708  
         min_range: 1000.0
         max_range: 1000.0
         yaw_range: [0.0, 0.0]
@@ -142,10 +147,11 @@ training:
     end:
       evader_start:
         distance_range: [8000.0, 12000.0]
+        initial_speed: 50.0
       pursuer_start:
         cone_half_angle: 1.5
         inner_cone_half_angle: 1.3
         min_range: 1000.0
         max_range: 5000.0
-        yaw_range: [-3.14159, 3.14159]
-        force_target_radius: 150.0
+        yaw_range: [-2, 2]
+        force_target_radius: 350.0

--- a/config.yaml
+++ b/config.yaml
@@ -115,6 +115,14 @@ training:
   eval_freq: 1000
   # Save a checkpoint every this many episodes. Set to 0 to disable.
   checkpoint_steps: 0
+  # Curriculum progression mode: linear | adaptive
+  curriculum_mode: linear
+  # Rolling success threshold for adaptive curriculum
+  curriculum_success_threshold: 0.8
+  # Number of evaluation results to average for adaptive curriculum
+  curriculum_window: 5
+  # Number of discrete curriculum stages
+  curriculum_stages: 5
   # Curriculum specifying how the starting conditions gradually expand
   # throughout training. The ``start`` dictionary defines the easiest
   # configuration while ``end`` corresponds to the final environment

--- a/config.yaml
+++ b/config.yaml
@@ -74,12 +74,9 @@ pursuer_start:
   cone_half_angle: 1.5
   # Minimum half angle of the pursuer spawn cone [rad]
   inner_cone_half_angle: 1.3
-  # Enable or disable spawn quadrants relative to the evader heading
-  sections:
-    front: false
-    left: true
-    right: true
-    back: false
+  # Horizontal angular range relative to directly behind the evader [rad]
+  # When set this overrides the ``sections`` breakdown into quadrants.
+  yaw_range: [-3.14159, 3.14159]
   # Minimum initial range from the evader [m]
   min_range: 1000.0
   # Maximum initial range from the evader [m]
@@ -118,3 +115,29 @@ training:
   eval_freq: 1000
   # Save a checkpoint every this many episodes. Set to 0 to disable.
   checkpoint_steps: 0
+  # Curriculum specifying how the starting conditions gradually expand
+  # throughout training. The ``start`` dictionary defines the easiest
+  # configuration while ``end`` corresponds to the final environment
+  # parameters. All numeric values are linearly interpolated from the
+  # beginning to the end of training.
+  curriculum:
+    start:
+      evader_start:
+        distance_range: [10000.0, 10000.0]
+      pursuer_start:
+        cone_half_angle: 0.0
+        inner_cone_half_angle: 0.0
+        min_range: 1000.0
+        max_range: 1000.0
+        yaw_range: [0.0, 0.0]
+        force_target_radius: 0.0
+    end:
+      evader_start:
+        distance_range: [8000.0, 12000.0]
+      pursuer_start:
+        cone_half_angle: 1.5
+        inner_cone_half_angle: 1.3
+        min_range: 1000.0
+        max_range: 5000.0
+        yaw_range: [-3.14159, 3.14159]
+        force_target_radius: 150.0

--- a/play.py
+++ b/play.py
@@ -152,15 +152,19 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = 
     )
     deg45 = np.deg2rad(45.0)
     base_yaw = np.arctan2(heading_dir[1], heading_dir[0])
-    ranges = []
-    if sections.get("front", True):
-        ranges.append((base_yaw - deg45, base_yaw + deg45))
-    if sections.get("right", True):
-        ranges.append((base_yaw - np.pi / 2 - deg45, base_yaw - np.pi / 2 + deg45))
-    if sections.get("back", True):
-        ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
-    if sections.get("left", True):
-        ranges.append((base_yaw + deg45, base_yaw + np.pi / 2 + deg45))
+    if "yaw_range" in p_cfg:
+        yaw_min, yaw_max = p_cfg["yaw_range"]
+        ranges = [(base_yaw + np.pi + yaw_min, base_yaw + np.pi + yaw_max)]
+    else:
+        ranges = []
+        if sections.get("front", True):
+            ranges.append((base_yaw - deg45, base_yaw + deg45))
+        if sections.get("right", True):
+            ranges.append((base_yaw - np.pi / 2 - deg45, base_yaw - np.pi / 2 + deg45))
+        if sections.get("back", True):
+            ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
+        if sections.get("left", True):
+            ranges.append((base_yaw + deg45, base_yaw + np.pi / 2 + deg45))
     draw_spawn_volume(
         ax,
         e_start_pos,

--- a/play.py
+++ b/play.py
@@ -99,9 +99,11 @@ def run_episode(model_path: str, use_ppo: bool = False, max_steps: int | None = 
             obs_t = torch.tensor(obs, dtype=torch.float32, device=device)
             if use_ppo:
                 mean, _ = model(obs_t)
+                std = model.std.expand_as(mean)
             else:
                 mean = model(obs_t)
-            dist = torch.distributions.Normal(mean, torch.ones_like(mean))
+                std = torch.ones_like(mean)
+            dist = torch.distributions.Normal(mean, std)
             action = dist.mean
         obs, r, done, _, info = env.step(action.cpu().numpy())
         pursuer_traj.append(env.env.pursuer_pos.copy())

--- a/plot_config.py
+++ b/plot_config.py
@@ -116,15 +116,19 @@ def main():
     heading[2] = 0.0
     base_yaw = np.arctan2(heading[1], heading[0])
     deg45 = np.deg2rad(45.0)
-    ranges = []
-    if sections.get("front", True):
-        ranges.append((base_yaw - deg45, base_yaw + deg45))
-    if sections.get("right", True):
-        ranges.append((base_yaw - np.pi/2 - deg45, base_yaw - np.pi/2 + deg45))
-    if sections.get("back", True):
-        ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
-    if sections.get("left", True):
-        ranges.append((base_yaw + deg45, base_yaw + np.pi/2 + deg45))
+    if "yaw_range" in p_cfg:
+        yaw_min, yaw_max = p_cfg["yaw_range"]
+        ranges = [(base_yaw + np.pi + yaw_min, base_yaw + np.pi + yaw_max)]
+    else:
+        ranges = []
+        if sections.get("front", True):
+            ranges.append((base_yaw - deg45, base_yaw + deg45))
+        if sections.get("right", True):
+            ranges.append((base_yaw - np.pi/2 - deg45, base_yaw - np.pi/2 + deg45))
+        if sections.get("back", True):
+            ranges.append((base_yaw + np.pi - deg45, base_yaw + np.pi + deg45))
+        if sections.get("left", True):
+            ranges.append((base_yaw + deg45, base_yaw + np.pi/2 + deg45))
 
     draw_spawn_volume(
         ax,

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -29,6 +29,40 @@ def load_config(path: str | None = None) -> dict:
 config = load_config()
 
 
+def _interpolate(start: float, end: float, progress: float) -> float:
+    """Linear interpolation helper."""
+    return start + (end - start) * progress
+
+
+def apply_curriculum(cfg: dict, start_cfg: dict, end_cfg: dict, progress: float) -> None:
+    """Recursively interpolate ``cfg`` between ``start_cfg`` and ``end_cfg``.
+
+    Only keys present in ``start_cfg`` and ``end_cfg`` are touched. Numeric
+    values are interpolated linearly while boolean values switch from the start
+    to the end setting halfway through the training run.
+    """
+
+    for key, start_val in start_cfg.items():
+        if key not in end_cfg or key not in cfg:
+            continue
+        end_val = end_cfg[key]
+        if isinstance(start_val, dict) and isinstance(end_val, dict):
+            apply_curriculum(cfg[key], start_val, end_val, progress)
+        elif isinstance(start_val, (int, float)) and isinstance(end_val, (int, float)):
+            cfg[key] = _interpolate(float(start_val), float(end_val), progress)
+        elif (
+            isinstance(start_val, (list, tuple))
+            and isinstance(end_val, (list, tuple))
+            and len(start_val) == len(end_val)
+        ):
+            cfg[key] = [
+                _interpolate(float(s), float(e), progress)
+                for s, e in zip(start_val, end_val)
+            ]
+        elif isinstance(start_val, bool) and isinstance(end_val, bool):
+            cfg[key] = end_val if progress >= 0.5 else start_val
+
+
 def sample_pursuer_start(evader_pos: np.ndarray, heading: np.ndarray, cfg: dict):
     """Sample initial pursuer state and force direction.
 
@@ -41,26 +75,31 @@ def sample_pursuer_start(evader_pos: np.ndarray, heading: np.ndarray, cfg: dict)
     inner = params.get("inner_cone_half_angle", 0.0)
     r = np.random.uniform(params["min_range"], params["max_range"])
 
-    # choose a spawn quadrant relative to the evader heading
     base_yaw = np.arctan2(heading[1], heading[0])
-    sections_cfg = params.get(
-        "sections",
-        {"front": True, "left": True, "right": True, "back": True},
-    )
-    quadrants = []
-    deg45 = np.deg2rad(45.0)
-    if sections_cfg.get("front", True):
-        quadrants.append((-deg45, deg45))
-    if sections_cfg.get("right", True):
-        quadrants.append((-deg45 - np.pi / 2, deg45 - np.pi / 2))
-    if sections_cfg.get("back", True):
-        quadrants.append((np.pi - deg45, np.pi + deg45))
-    if sections_cfg.get("left", True):
-        quadrants.append((deg45, deg45 + np.pi / 2))
-    if not quadrants:
-        raise ValueError("No pursuer spawn sections enabled")
-    yaw_rel = np.random.uniform(*quadrants[np.random.randint(len(quadrants))])
-    yaw = (base_yaw + yaw_rel) % (2 * np.pi)
+    if "yaw_range" in params:
+        # Angular range is measured relative to directly behind the evader.
+        yaw_min, yaw_max = params["yaw_range"]
+        yaw_rel = np.random.uniform(yaw_min, yaw_max)
+        yaw = (base_yaw + np.pi + yaw_rel) % (2 * np.pi)
+    else:
+        sections_cfg = params.get(
+            "sections",
+            {"front": True, "left": True, "right": True, "back": True},
+        )
+        quadrants = []
+        deg45 = np.deg2rad(45.0)
+        if sections_cfg.get("front", True):
+            quadrants.append((-deg45, deg45))
+        if sections_cfg.get("right", True):
+            quadrants.append((-deg45 - np.pi / 2, deg45 - np.pi / 2))
+        if sections_cfg.get("back", True):
+            quadrants.append((np.pi - deg45, np.pi + deg45))
+        if sections_cfg.get("left", True):
+            quadrants.append((deg45, deg45 + np.pi / 2))
+        if not quadrants:
+            raise ValueError("No pursuer spawn sections enabled")
+        yaw_rel = np.random.uniform(*quadrants[np.random.randint(len(quadrants))])
+        yaw = (base_yaw + yaw_rel) % (2 * np.pi)
 
     pitch = np.random.uniform(inner, outer)
     # direction from the evader to the pursuer in world coordinates

--- a/train_pursuer.py
+++ b/train_pursuer.py
@@ -11,6 +11,7 @@ import torch.optim as optim
 from torch.utils.tensorboard import SummaryWriter
 import gymnasium as gym
 from typing import Optional
+from collections import deque
 
 TABLE_HEADER = (
     f"{'step':>5} | {'pursuer→evader [m]':>26} | "
@@ -222,6 +223,10 @@ def train(
     curriculum_cfg = training_cfg.get('curriculum')
     start_cur = curriculum_cfg.get('start') if curriculum_cfg else None
     end_cur = curriculum_cfg.get('end') if curriculum_cfg else None
+    curriculum_mode = training_cfg.get('curriculum_mode', 'linear')
+    success_threshold = training_cfg.get('curriculum_success_threshold', 0.8)
+    success_window = training_cfg.get('curriculum_window', 5)
+    curriculum_stages = training_cfg.get('curriculum_stages', 5)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     env = PursuerOnlyEnv(cfg)
@@ -251,10 +256,22 @@ def train(
     )
 
     efficiency_logged = False
+    success_history = deque(maxlen=success_window)
+    stage_idx = 0
     for episode in range(num_episodes):
-        progress = episode / max(num_episodes - 1, 1)
-        if start_cur and end_cur:
-            apply_curriculum(env.env.cfg, start_cur, end_cur, progress)
+        if curriculum_mode == 'adaptive':
+            progress = stage_idx / max(curriculum_stages, 1)
+            if start_cur and end_cur:
+                apply_curriculum(
+                    env.env.cfg,
+                    {'pursuer_start': start_cur.get('pursuer_start', {})},
+                    {'pursuer_start': end_cur.get('pursuer_start', {})},
+                    progress,
+                )
+        else:
+            progress = episode / max(num_episodes - 1, 1)
+            if start_cur and end_cur:
+                apply_curriculum(env.env.cfg, start_cur, end_cur, progress)
         # Collect one episode of experience
         obs, _ = env.reset()
         init_pursuer_pos = env.env.pursuer_pos.copy()
@@ -341,7 +358,15 @@ def train(
             # Periodically report progress on separate evaluation episodes
             eval_cfg = copy.deepcopy(cfg)
             if start_cur and end_cur:
-                apply_curriculum(eval_cfg, start_cur, end_cur, progress)
+                if curriculum_mode == 'adaptive':
+                    apply_curriculum(
+                        eval_cfg,
+                        {'pursuer_start': start_cur.get('pursuer_start', {})},
+                        {'pursuer_start': end_cur.get('pursuer_start', {})},
+                        progress,
+                    )
+                else:
+                    apply_curriculum(eval_cfg, start_cur, end_cur, progress)
             avg_r, success = evaluate(policy, PursuerOnlyEnv(eval_cfg))
             print(f"Episode {episode+1}: avg_reward={avg_r:.2f} success={success:.2f}")
             if writer:
@@ -354,6 +379,18 @@ def train(
                 ):
                     writer.add_scalar("sweep/episodes_to_reward", episode + 1, 0)
                     efficiency_logged = True
+            if curriculum_mode == 'adaptive':
+                success_history.append(success)
+                if (
+                    len(success_history) >= success_window
+                    and np.mean(success_history) >= success_threshold
+                    and stage_idx < curriculum_stages
+                ):
+                    stage_idx += 1
+                    success_history.clear()
+                    print(
+                        f"Advancing curriculum stage to {stage_idx}/{curriculum_stages}"
+                    )
         if checkpoint_every and save_path and (episode + 1) % checkpoint_every == 0:
             base, ext = os.path.splitext(save_path)
             ckpt_path = f"{base}_ckpt_{episode+1}{ext}"
@@ -363,7 +400,15 @@ def train(
     # Final evaluation after training
     eval_cfg = copy.deepcopy(cfg)
     if start_cur and end_cur:
-        apply_curriculum(eval_cfg, start_cur, end_cur, 1.0)
+        if curriculum_mode == 'adaptive':
+            apply_curriculum(
+                eval_cfg,
+                {'pursuer_start': start_cur.get('pursuer_start', {})},
+                {'pursuer_start': end_cur.get('pursuer_start', {})},
+                stage_idx / max(curriculum_stages, 1),
+            )
+        else:
+            apply_curriculum(eval_cfg, start_cur, end_cur, 1.0)
     avg_r, success = evaluate(policy, PursuerOnlyEnv(eval_cfg))
     print(f"Final performance: avg_reward={avg_r:.2f} success={success:.2f}")
     if writer:
@@ -437,6 +482,27 @@ if __name__ == "__main__":
         default="runs/reinforce",
         help="write TensorBoard logs to this directory",
     )
+    parser.add_argument(
+        "--curriculum-mode",
+        type=str,
+        choices=["linear", "adaptive"],
+        help="progress curriculum linearly or adaptively",
+    )
+    parser.add_argument(
+        "--success-threshold",
+        type=float,
+        help="success rate required to advance adaptive curriculum",
+    )
+    parser.add_argument(
+        "--curriculum-window",
+        type=int,
+        help="number of evals to average for adaptive curriculum",
+    )
+    parser.add_argument(
+        "--curriculum-stages",
+        type=int,
+        help="number of discrete curriculum stages",
+    )
     args = parser.parse_args()
 
     training_cfg = config.setdefault('training', {
@@ -450,6 +516,10 @@ if __name__ == "__main__":
         'reward_threshold': 0.0,
         'eval_freq': 1000,
         'checkpoint_steps': 0,
+        'curriculum_mode': 'linear',
+        'curriculum_success_threshold': 0.8,
+        'curriculum_window': 5,
+        'curriculum_stages': 5,
     })
     if args.episodes is not None:
         training_cfg['episodes'] = args.episodes
@@ -471,6 +541,14 @@ if __name__ == "__main__":
         training_cfg['eval_freq'] = args.eval_freq
     if args.checkpoint_every is not None:
         training_cfg['checkpoint_steps'] = args.checkpoint_every
+    if args.curriculum_mode is not None:
+        training_cfg['curriculum_mode'] = args.curriculum_mode
+    if args.success_threshold is not None:
+        training_cfg['curriculum_success_threshold'] = args.success_threshold
+    if args.curriculum_window is not None:
+        training_cfg['curriculum_window'] = args.curriculum_window
+    if args.curriculum_stages is not None:
+        training_cfg['curriculum_stages'] = args.curriculum_stages
     if args.time_step is not None:
         config['time_step'] = args.time_step
 


### PR DESCRIPTION
## Summary
- make curriculum progression optionally adaptive
- add new config parameters and CLI flags
- update training scripts to track recent success rate
- document adaptive curriculum in README

## Testing
- `python -m py_compile train_pursuer.py`
- `python -m py_compile train_pursuer_ppo.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68719f005880833298c4dd1ad1223cee