### PR TITLE
Add heading alignment reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,9 @@ the section based spawning.  Combined with the `min_range` and
 the beginning of an episode.
 Both `pursuit_evasion.py` and `train_pursuer.py` load the configuration
 at runtime, so changes take effect the next time you run the scripts.
-The reward shaping parameters `shaping_weight`, `closer_weight` and
-`angle_weight` can be adjusted here as well to encourage desired
+The reward shaping parameters `shaping_weight`, `closer_weight`,
+`angle_weight` and `heading_weight` can be adjusted here as well to
+encourage desired
 behaviour. The `separation_cutoff_factor` option defines a multiplier of
 the initial pursuer--evader distance that ends the episode when the
 agents drift farther apart than this threshold.

--- a/config.yaml
+++ b/config.yaml
@@ -56,6 +56,8 @@ shaping_weight: 0.05
 closer_weight: 0.1
 # Additional reward weight for reducing the pursuer-to-evader angle
 angle_weight: 0.05
+# Additional reward weight for aligning the pursuer and evader headings
+heading_weight: 0.0
 # Extra reward multiplier for capturing before the time limit. The pursuer
 # receives ``1 + capture_bonus * (max_steps - episode_steps)`` when a capture
 # occurs, allowing earlier interceptions to yield higher returns.

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -161,6 +161,9 @@ class PursuitEvasionEnv(gym.Env):
         # Reward for reducing the angle between the pursuer's force direction
         # and the line of sight to the evader from one step to the next.
         self.angle_weight = self.cfg.get('angle_weight', 0.0)
+        # Reward for reducing the difference between the pursuer and
+        # evader headings from one step to the next.
+        self.heading_weight = self.cfg.get('heading_weight', 0.0)
         self.meas_err = self.cfg.get('measurement_error_pct', 0.0) / 100.0
         # maximum allowed separation before the episode ends
         self.cutoff_factor = self.cfg.get('separation_cutoff_factor', 2.0)
@@ -264,6 +267,10 @@ class PursuitEvasionEnv(gym.Env):
         self.prev_pe_dist = np.linalg.norm(self.evader_pos - self.pursuer_pos)
         vec_pe = self.evader_pos - self.pursuer_pos
         self.prev_pe_angle = self._angle_between(self.pursuer_force_dir, vec_pe)
+        # heading difference between the agents for shaping
+        h_e = self.evader_vel / (np.linalg.norm(self.evader_vel) + 1e-8)
+        h_p = self.pursuer_vel / (np.linalg.norm(self.pursuer_vel) + 1e-8)
+        self.prev_heading_angle = self._angle_between(h_p, h_e)
         # store the starting distance for logging
         self.start_pe_dist = self.prev_pe_dist
         target = np.array(self.cfg['target_position'], dtype=np.float32)
@@ -315,6 +322,16 @@ class PursuitEvasionEnv(gym.Env):
         if self.angle_weight > 0.0 and angle < self.prev_pe_angle:
             angle_bonus = self.angle_weight * (self.prev_pe_angle - angle)
         self.prev_pe_angle = angle
+        # Reward for aligning the pursuer and evader headings
+        h_e = self.evader_vel / (np.linalg.norm(self.evader_vel) + 1e-8)
+        h_p = self.pursuer_vel / (np.linalg.norm(self.pursuer_vel) + 1e-8)
+        head_ang = self._angle_between(h_p, h_e)
+        heading_bonus = 0.0
+        if self.heading_weight > 0.0 and head_ang < self.prev_heading_angle:
+            heading_bonus = self.heading_weight * (
+                self.prev_heading_angle - head_ang
+            )
+        self.prev_heading_angle = head_ang
         self.prev_pe_dist = dist_pe
         self.prev_target_dist = dist_target
 
@@ -323,6 +340,7 @@ class PursuitEvasionEnv(gym.Env):
         r_p += self.shaping_weight * shape_p
         r_p += closer_bonus
         r_p += angle_bonus
+        r_p += heading_bonus
         # small time penalty encouraging quick capture
         r_p -= 0.001
         obs = self._get_obs()


### PR DESCRIPTION
## Summary
- add a `heading_weight` config parameter for rewarding alignment of pursuer and evader headings
- implement heading alignment bonus in `PursuitEvasionEnv`
- document the new reward option in the README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py play.py plot_config.py sweep.py`

------
https://chatgpt.com/codex/tasks/task_e_6872d14e931c8332aefc95d9d18cb18d