### PR TITLE
Add ground crash penalty

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ goal and it falls off to zero once the evader is roughly 100&nbsp;m away by
 default. Episodes also end successfully when the airborne evader comes within
 100&nbsp;m of the goal. The radius for this check can be adjusted via the
 ``target_success_distance`` setting.
+If the pursuer crashes into the ground it receives a negative reward
+configured by ``pursuer_ground_penalty``.
 
 ## Sensor error model
 

--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,8 @@ heading_weight: 0.0
 # receives ``1 + capture_bonus * (max_steps - episode_steps)`` when a capture
 # occurs, allowing earlier interceptions to yield higher returns.
 capture_bonus: 0.0
+# Penalty applied when the pursuer crashes into the ground
+pursuer_ground_penalty: -1.0
 # Coordinates of the evader's goal [m]
 target_position: [0, 0.0, 0.0]
 evader_start:

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -167,6 +167,8 @@ class PursuitEvasionEnv(gym.Env):
         self.meas_err = self.cfg.get('measurement_error_pct', 0.0) / 100.0
         # maximum allowed separation before the episode ends
         self.cutoff_factor = self.cfg.get('separation_cutoff_factor', 2.0)
+        # penalty applied when the pursuer crashes into the ground
+        self.ground_penalty = self.cfg.get('pursuer_ground_penalty', -1.0)
         # Convert stall angles provided in degrees to radians once
         self.cfg['evader']['stall_angle'] = np.deg2rad(
             self.cfg['evader']['stall_angle']
@@ -501,7 +503,7 @@ class PursuitEvasionEnv(gym.Env):
 
         # episode ends if either agent goes below ground level
         if self.pursuer_pos[2] < 0.0:
-            return True, 0.0, -1.0
+            return True, 0.0, float(self.ground_penalty)
         if self.evader_pos[2] < 0.0:
             max_d = self.cfg.get('target_reward_distance', 100.0)
             reward = max(0.0, 1.0 - (dist_target / max_d) ** 2)


### PR DESCRIPTION
## Summary
- add `pursuer_ground_penalty` setting
- penalize pursuer in env when altitude drops below zero
- document pursuer ground penalty

## Testing
- `python -m py_compile pursuit_evasion.py`
- *(tests failed: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6872d6275a648332a57c86164f4d659a