### PR TITLE
Add pursuer ground crash penalty

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ using ``target_reward_distance``. A reward of one is given when it reaches the
 goal and it falls off to zero once the evader is roughly 100&nbsp;m away by
 default. Episodes also end successfully when the airborne evader comes within
 100&nbsp;m of the goal. The radius for this check can be adjusted via the
-``target_success_distance`` setting.
+``target_success_distance`` setting. The pursuer receives a configurable
+penalty, controlled by ``pursuer_ground_penalty``, when it crashes into the
+ground.
 
 ## Sensor error model
 

--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,8 @@ heading_weight: 0.0
 # receives ``1 + capture_bonus * (max_steps - episode_steps)`` when a capture
 # occurs, allowing earlier interceptions to yield higher returns.
 capture_bonus: 0.0
+# Penalty applied when the pursuer crashes into the ground
+pursuer_ground_penalty: -1.0
 # Coordinates of the evader's goal [m]
 target_position: [0, 0.0, 0.0]
 evader_start:

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -501,7 +501,8 @@ class PursuitEvasionEnv(gym.Env):
 
         # episode ends if either agent goes below ground level
         if self.pursuer_pos[2] < 0.0:
-            return True, 0.0, -1.0
+            penalty = self.cfg.get('pursuer_ground_penalty', -1.0)
+            return True, 0.0, penalty
         if self.evader_pos[2] < 0.0:
             max_d = self.cfg.get('target_reward_distance', 100.0)
             reward = max(0.0, 1.0 - (dist_target / max_d) ** 2)


### PR DESCRIPTION
## Summary
- make penalty for pursuer hitting the ground configurable
- document `pursuer_ground_penalty` in config and README

## Testing
- `pip install -r requirements.txt`
- `python - <<'EOF'
import pursuit_evasion as pe
env = pe.PursuitEvasionEnv(pe.config)
obs,_ = env.reset()
while not env._check_done()[0]:
    env.step({'evader':[0,0,0],'pursuer':[0,0,0]})
print(env._check_done()[1:])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6872d6275a648332a57c86164f4d659a