### PR TITLE
Improve training logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ tensorboard --logdir runs
 This will show episode rewards, evaluation results and losses during training.
 When a log directory is set, periodic checkpoints created with
 ``--checkpoint-every`` are stored under ``<log-dir>/checkpoints``.
+The logs also record a breakdown of the pursuer reward into shaping,
+alignment and terminal components as well as the fractions of each
+termination type aggregated over ``training.outcome_window`` episodes.
+When curriculum training is enabled the current angular and distance
+ranges are written under the ``curriculum/`` namespace so the schedule
+can be visualised over time.
 
 ### New training options
 

--- a/config.yaml
+++ b/config.yaml
@@ -117,6 +117,8 @@ training:
   reward_threshold: 0.0
   # Run evaluation episodes every this many training episodes
   eval_freq: 20000
+  # Episodes per bin for termination statistics
+  outcome_window: 100
   # Save a checkpoint every this many episodes. Set to 0 to disable.
   checkpoint_steps: 2000
   # Number of discrete curriculum stages including the final environment.


### PR DESCRIPTION
## Summary
- track reward components and termination fractions in TensorBoard
- expose curriculum progress in logs
- allow tuning termination statistic window
- document new metrics

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py`
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6872d853291c83329863d3bbf1fd20b5