### PR TITLE
Improve PPO logging for termination counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ When a log directory is set, periodic checkpoints created with
 The logs also record a breakdown of the pursuer reward into shaping,
 alignment and terminal components as well as the fractions of each
 termination type aggregated over ``training.outcome_window`` episodes.
+When running multiple environments in parallel the average minimum
+distance to the evader and mean episode length are logged under
+``train/min_distance`` and ``train/episode_length``.
+Every ``training.outcome_window`` episodes the script also prints the
+number of occurrences of each termination reason so you can quickly see
+how episodes are ending.
 When curriculum training is enabled the current angular and distance
 ranges are written under the ``curriculum/`` namespace so the schedule
 can be visualised over time.
@@ -190,10 +196,13 @@ which is useful for quickly checking that the environment works.
 
 The environment stores several statistics for each episode. When an episode
 finishes the ``info`` dictionary returned from ``env.step`` contains the
-closest pursuer--evader distance, number of steps and outcome (capture,
-evader reaching the target while airborne, separation exceeding a multiple of the starting distance (controlled by ``separation_cutoff_factor`` in ``env.yaml``) or timeout). The evaluation helpers in the training
-scripts print the average minimum distance and episode length during
-periodic evaluations.
+closest pursuer--evader distance, number of steps and outcome. The outcome can
+be ``capture`` (pursuer success), ``evader_success`` (reaches the target in the
+air), ``evader_ground`` or ``pursuer_ground`` when a crash occurs,
+``separation_exceeded`` if the starting distance has grown beyond the
+``separation_cutoff_factor`` multiple, or ``timeout`` when the step limit is
+reached. The evaluation helpers in the training scripts print the average
+minimum distance and episode length during periodic evaluations.
 
 ## Adjusting environment parameters
 

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -221,6 +221,7 @@ def evaluate(model: ActorCritic, env: PursuerOnlyEnv, episodes: int = 5):
     successes = 0
     min_dists = []
     steps = []
+    outcome_counts = defaultdict(int)
     for _ in range(episodes):
         obs, _ = env.reset()
         done = False
@@ -241,12 +242,15 @@ def evaluate(model: ActorCritic, env: PursuerOnlyEnv, episodes: int = 5):
         if info:
             min_dists.append(info.get('min_distance', np.nan))
             steps.append(info.get('episode_steps', np.nan))
+            outcome_counts[info.get('outcome', 'timeout')] += 1
 
     if min_dists:
         print(
             f"    eval metrics: mean_min_dist={np.nanmean(min_dists):.2f} "
             f"mean_steps={np.nanmean(steps):.1f}"
         )
+    if outcome_counts:
+        print(f"    termination counts: {dict(outcome_counts)}")
     return float(np.mean(rewards)), successes / episodes
 
 
@@ -553,6 +557,10 @@ def train(
                         writer.add_scalar(
                             f"termination/{k}", c / total, episode
                         )
+                    print(
+                        f"Termination counts (last {outcome_window} episodes): "
+                        f"{dict(outcome_counts)}"
+                    )
                     outcome_counts = defaultdict(int)
                 print(
                     f"Episode {episode+1}: reward={episode_reward:.2f} "
@@ -570,6 +578,20 @@ def train(
             episode_reward = sum(sum(r) for r in rewards) / num_envs
             if writer:
                 writer.add_scalar("train/episode_reward", episode_reward, episode)
+                md_vals = [inf.get("min_distance", float("nan")) for inf in infos if inf]
+                step_vals = [inf.get("episode_steps", float("nan")) for inf in infos if inf]
+                if md_vals:
+                    writer.add_scalar(
+                        "train/min_distance",
+                        float(np.nanmean(md_vals)),
+                        episode,
+                    )
+                if step_vals:
+                    writer.add_scalar(
+                        "train/episode_length",
+                        float(np.nanmean(step_vals)),
+                        episode,
+                    )
                 rb_sum = defaultdict(float)
                 n_info = 0
                 for inf in infos:
@@ -589,6 +611,10 @@ def train(
                         writer.add_scalar(
                             f"termination/{k}", c / total, episode
                         )
+                    print(
+                        f"Termination counts (last {outcome_window} episodes): "
+                        f"{dict(outcome_counts)}"
+                    )
                     outcome_counts = defaultdict(int)
 
         if (episode + 1) % eval_freq == 0:


### PR DESCRIPTION
## Summary
- show termination counts each window in PPO trainer
- log average episode length and min distance with multiple envs
- print termination counts during evaluation
- document new metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872e26dab708332b8ca0a6033fee3df