### PR TITLE
Use final curriculum config during eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ The defaults for these options live in ``training.yaml`` and can be
 modified directly in that file.
 
 It will print evaluation statistics every ``--eval-freq`` episodes and a final
-summary when training finishes.
+summary when training finishes. When curriculum training is enabled these
+evaluation episodes always use the final environment configuration so progress
+is measured against the target difficulty.
 
 ### Monitoring training with TensorBoard
 

--- a/train_pursuer.py
+++ b/train_pursuer.py
@@ -427,7 +427,10 @@ def train(
             # Periodically report progress on separate evaluation episodes
             eval_cfg = copy.deepcopy(cfg)
             if start_cur and end_cur:
-                apply_curriculum(eval_cfg, start_cur, end_cur, progress)
+                # Use the final curriculum values for evaluation episodes to
+                # measure performance in the target environment rather than
+                # the current training stage.
+                apply_curriculum(eval_cfg, start_cur, end_cur, 1.0)
             avg_r, success = evaluate(policy, PursuerOnlyEnv(eval_cfg))
             print(f"Episode {episode+1}: avg_reward={avg_r:.2f} success={success:.2f}")
             if writer:

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -681,7 +681,10 @@ def train(
         if (episode + 1) % eval_freq == 0:
             eval_cfg = copy.deepcopy(cfg)
             if start_cur and end_cur:
-                apply_curriculum(eval_cfg, start_cur, end_cur, progress)
+                # Use final curriculum parameters when evaluating to track
+                # performance in the target environment regardless of the
+                # current training stage.
+                apply_curriculum(eval_cfg, start_cur, end_cur, 1.0)
             avg_r, success = evaluate(model, PursuerOnlyEnv(eval_cfg))
             print(
                 f"Episode {episode+1}: avg_reward={avg_r:.2f} success={success:.2f}"


### PR DESCRIPTION
## Summary
- evaluate policy with the final curriculum parameters during curriculum training
- document evaluation behaviour in README

## Testing
- `python -m py_compile train_pursuer.py train_pursuer_ppo.py play.py plot_config.py pursuit_evasion.py sweep.py`
- `pip install numpy torch gymnasium matplotlib pyyaml` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6872f81aab188332b450f9c454c93ce5