### PR TITLE
Add pursuer speed curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ the end configuration. Progress within a stage is computed as
 the pursuer's `yaw_range` and initial `force_target_radius` to begin the
 agent immediately behind the evader while increasing `evader_start.initial_speed`
 from 0&nbsp;m/s to 50&nbsp;m/s before expanding to the full search
-area. The curriculum makes it possible to smoothly transition from simple
+area. The pursuer's own starting velocity can be scheduled with
+`pursuer_start.initial_speed_range` so early stages may use a fixed
+speed while later ones draw from a wider range. The curriculum makes it
+possible to smoothly transition from simple
 encounters to more challenging ones. The length of the success history
 used by the adaptive curriculum is controlled with ``curriculum_window``
 while ``curriculum_stages`` defines how many intermediate steps exist
@@ -246,6 +249,10 @@ pursuer approaching from behind).  When `yaw_range` is present it overrides
 the section based spawning.  Combined with the `min_range` and
 `max_range` distances these options define where the pursuer may appear at
 the beginning of an episode.
+The initial speed of the pursuer is drawn uniformly from
+`pursuer_start.initial_speed_range`, which can also be modified via the
+training curriculum to gradually narrow or expand the spawn speed
+interval.
 Both `pursuit_evasion.py` and `train_pursuer.py` load the configuration
 at runtime, so changes take effect the next time you run the scripts.
 The reward shaping parameters `shaping_weight`, `closer_weight`,

--- a/training.yaml
+++ b/training.yaml
@@ -47,11 +47,13 @@ training:
         distance_range: [10000.0, 10000.0]
         initial_speed: 0.0
       pursuer_start:
-        cone_half_angle: 1.5708  
-        inner_cone_half_angle: 1.5708  
+        cone_half_angle: 1.5708
+        inner_cone_half_angle: 1.5708
         min_range: 1000.0
         max_range: 1000.0
         yaw_range: [0.0, 0.0]
+        # Initial pursuer speed sampled from this range [m/s]
+        initial_speed_range: [75.0, 75.0]
         force_target_radius: 0.0
     end:
       evader_start:
@@ -63,4 +65,6 @@ training:
         min_range: 1000.0
         max_range: 5000.0
         yaw_range: [-2, 2]
+        # Final range of pursuer spawn speeds [m/s]
+        initial_speed_range: [50.0, 75.0]
         force_target_radius: 350.0


### PR DESCRIPTION
## Summary
- add `pursuer_start.initial_speed_range` to curriculum config
- document pursuer speed range scheduling in README

## Testing
- `python -m py_compile train_pursuer.py train_pursuer_ppo.py play.py pursuit_evasion.py plot_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6873071a6568833291c76ffbc6d88a2c