### PR TITLE
Switch curriculum interpolation to logarithmic

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,13 @@ Both training scripts optionally support gradually increasing the starting
 difficulty of each episode. The ``training.curriculum`` section in
 ``training.yaml`` contains ``start`` and ``end`` dictionaries with values that are
 interpolated over the course of training. Any numeric field under these
-dictionaries will be linearly scaled from the `start` value to the `end`
-value. The `training.curriculum_stages` option specifies how many discrete
-stages are used, with ``N`` meaning ``N - 1`` transitions from the start to
-the end configuration. Progress within a stage is computed as
+dictionaries is interpolated logarithmically from the ``start`` value to the
+``end`` value when both numbers are positive. This produces small increments
+early on and larger jumps later in training. Values crossing or equal to zero
+fall back to linear interpolation. The ``training.curriculum_stages`` option
+specifies how many discrete stages are used, with ``N`` meaning ``N - 1``
+transitions from the start to the end configuration. Progress within a stage is
+computed as
 ``stage_idx / max(curriculum_stages - 1, 1)``. For example, the default configuration narrows
 the pursuer's `yaw_range` and initial `force_target_radius` to begin the
 agent immediately behind the evader while increasing `evader_start.initial_speed`
@@ -164,8 +167,8 @@ between the ``start`` and ``end`` configuration.
 The following command line arguments, accepted by both ``train_pursuer.py``
 and ``train_pursuer_ppo.py``, tune the curriculum behaviour:
 
-- ``--curriculum-mode`` – ``linear`` linearly interpolates from ``start`` to
-  ``end`` while ``adaptive`` only advances when the success threshold is
+- ``--curriculum-mode`` – ``linear`` progresses through the curriculum at a
+  fixed rate while ``adaptive`` only advances when the success threshold is
   met.
 - ``--success-threshold`` – fraction of recent episodes that must succeed
   before moving to the next curriculum stage.

--- a/training.yaml
+++ b/training.yaml
@@ -22,10 +22,9 @@ training:
   outcome_window: 100
   # Save a checkpoint every this many episodes. Set to 0 to disable.
   checkpoint_steps: 2000
-  # Curriculum progression strategy: "linear" interpolates from the
-  # starting configuration to the final one over a fixed number of
-  # stages while "adaptive" advances only when the recent success
-  # rate exceeds ``success_threshold``.
+  # Curriculum progression strategy: "linear" moves through the
+  # curriculum stages at a fixed rate while "adaptive" advances only
+  # when the recent success rate exceeds ``success_threshold``.
   curriculum_mode: linear
   # Minimum fraction of successful episodes required to move to the
   # next curriculum stage when ``curriculum_mode`` is "adaptive".
@@ -39,8 +38,8 @@ training:
   # Curriculum specifying how the starting conditions gradually expand
   # throughout training. The ``start`` dictionary defines the easiest
   # configuration while ``end`` corresponds to the final environment
-  # parameters. All numeric values are linearly interpolated from the
-  # beginning to the end of training.
+  # parameters. All numeric values are interpolated logarithmically when
+  # positive, falling back to linear interpolation otherwise.
   curriculum:
     start:
       evader_start:


### PR DESCRIPTION
## Summary
- change `_interpolate` so curriculum values grow logarithmically when possible
- describe new interpolation behaviour in README
- clarify curriculum comments in `training.yaml`

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer.py train_pursuer_ppo.py play.py plot_config.py sweep.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737d70cbd083329c9d6b0f5fa8a0cd