### PR TITLE
Fix reward logging and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ When running PPO with multiple environments the logger now reports the
 mean minimum pursuer--evader distance and episode length across all
 environments.  A summary of how many episodes ended in each termination
 state is printed every iteration for easier monitoring.
+Reward breakdown metrics are averaged across all environments so the
+``train/reward_*`` values reflect the mean contribution of each component
+per episode.
 
 ### New training options
 

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -739,7 +739,7 @@ def train(
                             start_list.append(inf["start_distance"])
                 if n_info:
                     for k, v in rb_sum.items():
-                        scalar_reward = float((v / n_info).mean())
+                        scalar_reward = float(v / n_info)
                         writer.add_scalar(f"train/reward_{k}", scalar_reward, episode)
                 for i, inf in enumerate(infos):
                     if inf:


### PR DESCRIPTION
## Summary
- fix averaging of reward breakdown in multi-env training
- document new reward aggregation in README

## Testing
- `python -m py_compile train_pursuer_ppo.py`
- `python -m py_compile pursuit_evasion.py play.py plot_config.py sweep.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68745b97db208332828cb2d8cd62daf9