### PR TITLE
Add action delta metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ episode statistics for each environment are written under the
 ``episode/`` namespace, while the mean values for the batch are logged
 under ``batch/``. A ``timing/episodes_per_sec`` metric tracks how many
 episodes are processed per second of wall time.
+The logger also records the cumulative change in the pursuer's commanded
+acceleration, yaw and pitch for each episode as ``train/acc_delta``,
+``train/yaw_delta`` and ``train/pitch_delta``. These per-episode totals
+are written for every environment under the ``episode/`` namespace.
 Every ``training.outcome_window`` episodes the script also prints the
 number of occurrences of each termination reason so you can quickly see
 how episodes are ending.
@@ -232,6 +236,8 @@ minimum distance and episode length during periodic evaluations.
 The logged ``min_start_ratio`` metric records how close the pursuer got
 relative to where it spawned (minimum distance divided by the starting
 separation).
+The total change in the pursuer's action commands over an episode is
+available via the ``*_delta`` metrics described above.
 
 ## Adjusting environment parameters
 

--- a/play.py
+++ b/play.py
@@ -140,6 +140,15 @@ def run_episode(model_path: str, max_steps: int | None = None) -> None:
             f"ratio={ratio}  "
             f"outcome={info.get('outcome', 'unknown')}"
         )
+        acc_d = info.get('pursuer_acc_delta')
+        yaw_d = info.get('pursuer_yaw_delta')
+        pitch_d = info.get('pursuer_pitch_delta')
+        if acc_d is not None and yaw_d is not None and pitch_d is not None:
+            print(
+                f"acc_delta={acc_d:.2f}  "
+                f"yaw_delta={yaw_d:.2f}  "
+                f"pitch_delta={pitch_d:.2f}"
+            )
 
     # Plot the trajectories in 3D
     fig = plt.figure()

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -608,6 +608,51 @@ def train(
                         float(min_d) / float(start_d),
                         episode_counter,
                     )
+                writer.add_scalar(
+                    "train/acc_delta",
+                    info.get("pursuer_acc_delta", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "batch/acc_delta",
+                    info.get("pursuer_acc_delta", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "episode/acc_delta",
+                    info.get("pursuer_acc_delta", float("nan")),
+                    episode_counter,
+                )
+                writer.add_scalar(
+                    "train/yaw_delta",
+                    info.get("pursuer_yaw_delta", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "batch/yaw_delta",
+                    info.get("pursuer_yaw_delta", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "episode/yaw_delta",
+                    info.get("pursuer_yaw_delta", float("nan")),
+                    episode_counter,
+                )
+                writer.add_scalar(
+                    "train/pitch_delta",
+                    info.get("pursuer_pitch_delta", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "batch/pitch_delta",
+                    info.get("pursuer_pitch_delta", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "episode/pitch_delta",
+                    info.get("pursuer_pitch_delta", float("nan")),
+                    episode_counter,
+                )
                 rb = info.get("reward_breakdown", {})
                 for k, v in rb.items():
                     scalar_reward = float(v)
@@ -709,11 +754,29 @@ def train(
                                 float(min_d) / float(start_d),
                                 episode_counter + i,
                             )
+                        writer.add_scalar(
+                            "episode/acc_delta",
+                            float(inf.get("pursuer_acc_delta", float("nan"))),
+                            episode_counter + i,
+                        )
+                        writer.add_scalar(
+                            "episode/yaw_delta",
+                            float(inf.get("pursuer_yaw_delta", float("nan"))),
+                            episode_counter + i,
+                        )
+                        writer.add_scalar(
+                            "episode/pitch_delta",
+                            float(inf.get("pursuer_pitch_delta", float("nan"))),
+                            episode_counter + i,
+                        )
                 rb_sum = defaultdict(float)
                 n_info = 0
                 min_list = []
                 len_list = []
                 start_list = []
+                acc_list = []
+                yaw_list = []
+                pitch_list = []
                 for inf in infos:
                     if inf:
                         n_info += 1
@@ -737,6 +800,12 @@ def train(
                             len_list.append(inf["episode_steps"])
                         if "start_distance" in inf:
                             start_list.append(inf["start_distance"])
+                        if "pursuer_acc_delta" in inf:
+                            acc_list.append(inf["pursuer_acc_delta"])
+                        if "pursuer_yaw_delta" in inf:
+                            yaw_list.append(inf["pursuer_yaw_delta"])
+                        if "pursuer_pitch_delta" in inf:
+                            pitch_list.append(inf["pursuer_pitch_delta"])
                 if n_info:
                     for k, v in rb_sum.items():
                         scalar_reward = float(v / n_info)
@@ -754,6 +823,15 @@ def train(
                     if len_list:
                         writer.add_scalar("train/episode_length", float(np.mean(len_list)), episode)
                         writer.add_scalar("batch/episode_length", float(np.mean(len_list)), episode)
+                    if acc_list:
+                        writer.add_scalar("train/acc_delta", float(np.mean(acc_list)), episode)
+                        writer.add_scalar("batch/acc_delta", float(np.mean(acc_list)), episode)
+                    if yaw_list:
+                        writer.add_scalar("train/yaw_delta", float(np.mean(yaw_list)), episode)
+                        writer.add_scalar("batch/yaw_delta", float(np.mean(yaw_list)), episode)
+                    if pitch_list:
+                        writer.add_scalar("train/pitch_delta", float(np.mean(pitch_list)), episode)
+                        writer.add_scalar("batch/pitch_delta", float(np.mean(pitch_list)), episode)
                     if min_list and start_list:
                         ratios = [m / s for m, s in zip(min_list, start_list) if s > 0]
                         if ratios:


### PR DESCRIPTION
## Summary
- track cumulative change in commanded acceleration and angles
- log these deltas to TensorBoard during training
- expose the new metrics when playing a saved model
- document new logging fields in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer_ppo.py play.py`
- ❌ `python train_pursuer_ppo.py --episodes 1 --log-dir /tmp/test_logs --num-envs 1 --time-step 0.1` (failed to install dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68754fb7c5808332bc99e723c25017e0