### PR TITLE
Add yaw/pitch diff metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The logger also records the cumulative change in the pursuer's commanded
 acceleration, yaw and pitch for each episode as ``train/acc_delta``,
 ``train/yaw_delta`` and ``train/pitch_delta``. These per-episode totals
 are written for every environment under the ``episode/`` namespace.
+The difference between the starting and final pursuer orientation is logged as
+``train/yaw_diff`` and ``train/pitch_diff``.
 Every ``training.outcome_window`` episodes the script also prints the
 number of occurrences of each termination reason so you can quickly see
 how episodes are ending.

--- a/play.py
+++ b/play.py
@@ -143,11 +143,15 @@ def run_episode(model_path: str, max_steps: int | None = None) -> None:
         acc_d = info.get('pursuer_acc_delta')
         yaw_d = info.get('pursuer_yaw_delta')
         pitch_d = info.get('pursuer_pitch_delta')
+        yaw_diff = info.get('pursuer_yaw_diff')
+        pitch_diff = info.get('pursuer_pitch_diff')
         if acc_d is not None and yaw_d is not None and pitch_d is not None:
             print(
                 f"acc_delta={acc_d:.2f}  "
                 f"yaw_delta={yaw_d:.2f}  "
-                f"pitch_delta={pitch_d:.2f}"
+                f"pitch_delta={pitch_d:.2f}  "
+                f"yaw_diff={yaw_diff:.2f}  "
+                f"pitch_diff={pitch_diff:.2f}"
             )
 
     # Plot the trajectories in 3D

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -287,6 +287,15 @@ class PursuitEvasionEnv(gym.Env):
         self.pursuer_vel = p_vel.astype(np.float32)
         self.pursuer_force_dir = p_dir.astype(np.float32)
         self.pursuer_force_mag = 0.0
+        # store initial yaw/pitch of both agents for logging
+        self.init_pursuer_yaw = float(np.arctan2(self.pursuer_force_dir[1], self.pursuer_force_dir[0]))
+        self.init_pursuer_pitch = float(
+            np.arctan2(self.pursuer_force_dir[2], np.linalg.norm(self.pursuer_force_dir[:2]))
+        )
+        self.init_evader_yaw = float(np.arctan2(self.evader_force_dir[1], self.evader_force_dir[0]))
+        self.init_evader_pitch = float(
+            np.arctan2(self.evader_force_dir[2], np.linalg.norm(self.evader_force_dir[:2]))
+        )
         # record baseline distances for shaping rewards
         self.prev_pe_dist = np.linalg.norm(self.evader_pos - self.pursuer_pos)
         vec_pe = self.evader_pos - self.pursuer_pos
@@ -430,6 +439,23 @@ class PursuitEvasionEnv(gym.Env):
             info['pursuer_acc_delta'] = float(self.pursuer_acc_delta)
             info['pursuer_yaw_delta'] = float(self.pursuer_yaw_delta)
             info['pursuer_pitch_delta'] = float(self.pursuer_pitch_delta)
+            # difference between starting and final orientation of both agents
+            p_yaw = np.arctan2(self.pursuer_force_dir[1], self.pursuer_force_dir[0])
+            p_pitch = np.arctan2(
+                self.pursuer_force_dir[2], np.linalg.norm(self.pursuer_force_dir[:2])
+            )
+            yaw_diff = np.arctan2(np.sin(p_yaw - self.init_pursuer_yaw), np.cos(p_yaw - self.init_pursuer_yaw))
+            pitch_diff = p_pitch - self.init_pursuer_pitch
+            info['pursuer_yaw_diff'] = float(yaw_diff)
+            info['pursuer_pitch_diff'] = float(pitch_diff)
+            e_yaw = np.arctan2(self.evader_force_dir[1], self.evader_force_dir[0])
+            e_pitch = np.arctan2(
+                self.evader_force_dir[2], np.linalg.norm(self.evader_force_dir[:2])
+            )
+            info['evader_yaw_diff'] = float(
+                np.arctan2(np.sin(e_yaw - self.init_evader_yaw), np.cos(e_yaw - self.init_evader_yaw))
+            )
+            info['evader_pitch_diff'] = float(e_pitch - self.init_evader_pitch)
         # update stored previous positions for next step
         self.prev_pursuer_pos = prev_p_pos
         self.prev_evader_pos = prev_e_pos

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -653,6 +653,36 @@ def train(
                     info.get("pursuer_pitch_delta", float("nan")),
                     episode_counter,
                 )
+                writer.add_scalar(
+                    "train/yaw_diff",
+                    info.get("pursuer_yaw_diff", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "batch/yaw_diff",
+                    info.get("pursuer_yaw_diff", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "episode/yaw_diff",
+                    info.get("pursuer_yaw_diff", float("nan")),
+                    episode_counter,
+                )
+                writer.add_scalar(
+                    "train/pitch_diff",
+                    info.get("pursuer_pitch_diff", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "batch/pitch_diff",
+                    info.get("pursuer_pitch_diff", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "episode/pitch_diff",
+                    info.get("pursuer_pitch_diff", float("nan")),
+                    episode_counter,
+                )
                 rb = info.get("reward_breakdown", {})
                 for k, v in rb.items():
                     scalar_reward = float(v)
@@ -777,6 +807,8 @@ def train(
                 acc_list = []
                 yaw_list = []
                 pitch_list = []
+                yaw_diff_list = []
+                pitch_diff_list = []
                 for inf in infos:
                     if inf:
                         n_info += 1
@@ -808,6 +840,10 @@ def train(
                             yaw_list.append(inf["pursuer_yaw_delta"])
                         if "pursuer_pitch_delta" in inf:
                             pitch_list.append(inf["pursuer_pitch_delta"])
+                        if "pursuer_yaw_diff" in inf:
+                            yaw_diff_list.append(inf["pursuer_yaw_diff"])
+                        if "pursuer_pitch_diff" in inf:
+                            pitch_diff_list.append(inf["pursuer_pitch_diff"])
                 if n_info:
                     for k, v in rb_sum.items():
                         avg = v / n_info
@@ -835,6 +871,12 @@ def train(
                     if pitch_list:
                         writer.add_scalar("train/pitch_delta", float(np.mean(pitch_list)), episode)
                         writer.add_scalar("batch/pitch_delta", float(np.mean(pitch_list)), episode)
+                    if yaw_diff_list:
+                        writer.add_scalar("train/yaw_diff", float(np.mean(yaw_diff_list)), episode)
+                        writer.add_scalar("batch/yaw_diff", float(np.mean(yaw_diff_list)), episode)
+                    if pitch_diff_list:
+                        writer.add_scalar("train/pitch_diff", float(np.mean(pitch_diff_list)), episode)
+                        writer.add_scalar("batch/pitch_diff", float(np.mean(pitch_diff_list)), episode)
                     if min_list and start_list:
                         ratios = [m / s for m, s in zip(min_list, start_list) if s > 0]
                         if ratios:


### PR DESCRIPTION
## Summary
- record initial pursuer/evader orientation on reset
- log yaw/pitch difference at episode end
- expose new metrics in training script and play script
- document new metrics in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer_ppo.py play.py plot_config.py`

------
https://chatgpt.com/codex/tasks/task_e_687572c6e2a48332a8bd35751f776614