### PR TITLE
Add capture cone reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This will show episode rewards, evaluation results and losses during training.
 When a log directory is set, periodic checkpoints created with
 ``--checkpoint-every`` are stored under ``<log-dir>/checkpoints``.
 The logs also record a breakdown of the pursuer reward into shaping,
-alignment and terminal components as well as the fractions of each
+alignment, cone and terminal components as well as the fractions of each
 termination type aggregated over ``training.outcome_window`` episodes.
 When running multiple environments in parallel the average minimum
 distance to the evader and mean episode length are logged under
@@ -270,8 +270,8 @@ interval.
 Both `pursuit_evasion.py` and `train_pursuer_ppo.py` load the configuration
 at runtime, so changes take effect the next time you run the script.
 The reward shaping parameters `shaping_weight`, `closer_weight`,
-`angle_weight` and `heading_weight` can be adjusted here as well to
-encourage desired
+`angle_weight`, `heading_weight` and `capture_cone_weight` can be adjusted
+here as well to encourage desired
 behaviour. The `separation_cutoff_factor` option defines a multiplier of
 the initial pursuer--evader distance that ends the episode when the
 agents drift farther apart than this threshold.

--- a/env.yaml
+++ b/env.yaml
@@ -16,6 +16,11 @@ closer_weight: 0.1
 angle_weight: 0.1
 # Additional reward weight for aligning the pursuer and evader headings
 heading_weight: 0.1
+# Reward weight for keeping the pursuer pointed at the evader's
+# capture sphere. The bonus scales with the inverse distance to the
+# evader when the pursuer maintains its heading inside the capture
+# cone between consecutive steps.
+capture_cone_weight: 0.0
 # Extra reward multiplier for capturing before the time limit. The pursuer
 # receives ``1 + capture_bonus * (max_steps - episode_steps)`` when a capture
 # occurs, allowing earlier interceptions to yield higher returns.

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -188,6 +188,10 @@ class PursuitEvasionEnv(gym.Env):
         # Reward for reducing the difference between the pursuer and
         # evader headings from one step to the next.
         self.heading_weight = self.cfg.get('heading_weight', 0.0)
+        # Bonus for keeping the pursuer pointed inside the evader's
+        # capture cone across consecutive steps. Scales with the
+        # inverse distance to the evader.
+        self.capture_cone_weight = self.cfg.get('capture_cone_weight', 0.0)
         self.meas_err = self.cfg.get('measurement_error_pct', 0.0) / 100.0
         # maximum allowed separation before the episode ends
         self.cutoff_factor = self.cfg.get('separation_cutoff_factor', 2.0)
@@ -315,6 +319,7 @@ class PursuitEvasionEnv(gym.Env):
             'closer': 0.0,
             'angle': 0.0,
             'heading': 0.0,
+            'cone': 0.0,
             'time': 0.0,
         }
         # metrics for episode statistics
@@ -329,6 +334,13 @@ class PursuitEvasionEnv(gym.Env):
         # store previous positions to detect capture between steps
         self.prev_pursuer_pos = self.pursuer_pos.copy()
         self.prev_evader_pos = self.evader_pos.copy()
+        vec_pe = self.evader_pos - self.pursuer_pos
+        cone_angle = np.arcsin(
+            min(1.0, self.cfg['capture_radius'] / (self.prev_pe_dist + 1e-8))
+        )
+        self.prev_cone_aligned = (
+            self._angle_between(self.pursuer_force_dir, vec_pe) <= cone_angle
+        )
         return self._get_obs(), {}
 
     def step(self, action: dict):
@@ -354,6 +366,7 @@ class PursuitEvasionEnv(gym.Env):
         self.prev_pursuer_action = pursuer_action
         prev_p_pos = self.pursuer_pos.copy()
         prev_e_pos = self.evader_pos.copy()
+        prev_dir = self.pursuer_force_dir.copy()
         self._update_agent('evader', evader_action)
         self._update_agent('pursuer', pursuer_action)
         # shaping rewards based on change in distances
@@ -389,6 +402,28 @@ class PursuitEvasionEnv(gym.Env):
                 self.prev_heading_angle - head_ang
             )
         self.prev_heading_angle = head_ang
+
+        cone_bonus = 0.0
+        if self.capture_cone_weight > 0.0:
+            prev_vec = prev_e_pos - prev_p_pos
+            prev_cone = np.arcsin(
+                min(1.0, self.cfg['capture_radius'] / (self.prev_pe_dist + 1e-8))
+            )
+            prev_ang = self._angle_between(prev_dir, prev_vec)
+            cone_angle = np.arcsin(
+                min(1.0, self.cfg['capture_radius'] / (dist_pe + 1e-8))
+            )
+            in_prev = self.prev_cone_aligned and prev_ang <= prev_cone
+            in_cur = angle <= cone_angle
+            self.prev_cone_aligned = in_cur
+            if in_prev and in_cur:
+                cone_bonus = self.capture_cone_weight * (
+                    self.cfg['capture_radius'] / (dist_pe + 1e-8)
+                )
+        else:
+            self.prev_cone_aligned = angle <= np.arcsin(
+                min(1.0, self.cfg['capture_radius'] / (dist_pe + 1e-8))
+            )
         self.prev_pe_dist = dist_pe
         self.prev_target_dist = dist_target
 
@@ -401,6 +436,7 @@ class PursuitEvasionEnv(gym.Env):
             + closer_bonus
             + angle_bonus
             + heading_bonus
+            + cone_bonus
             - 0.001
         )
         self._reward_breakdown['terminal'] += r_p_terminal
@@ -408,6 +444,7 @@ class PursuitEvasionEnv(gym.Env):
         self._reward_breakdown['closer'] += closer_bonus
         self._reward_breakdown['angle'] += angle_bonus
         self._reward_breakdown['heading'] += heading_bonus
+        self._reward_breakdown['cone'] += cone_bonus
         self._reward_breakdown['time'] += -0.001
         obs = self._get_obs()
         reward = {'evader': r_e, 'pursuer': r_p}


### PR DESCRIPTION
## Summary
- add `capture_cone_weight` to env config
- reward pursuer for maintaining heading pointed at evader
- document new reward in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer_ppo.py play.py plot_config.py`

------
https://chatgpt.com/codex/tasks/task_e_687576cc09788332be1fad1900cc6664