### PR TITLE
Add cone timing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ acceleration, yaw and pitch for each episode as ``train/acc_delta``,
 are written for every environment under the ``episode/`` namespace.
 The difference between the starting and final pursuer orientation is logged as
 ``train/yaw_diff`` and ``train/pitch_diff``.
+The time spent computing the capture cone reward is recorded under
+``train/cone_time`` and ``batch/cone_time`` with per-episode values in
+``episode/cone_time``.
 Every ``training.outcome_window`` episodes the script also prints the
 number of occurrences of each termination reason so you can quickly see
 how episodes are ending.

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -698,6 +698,21 @@ def train(
                     info.get("pursuer_pitch_diff", float("nan")),
                     episode_counter,
                 )
+                writer.add_scalar(
+                    "train/cone_time",
+                    info.get("cone_calc_time", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "batch/cone_time",
+                    info.get("cone_calc_time", float("nan")),
+                    episode,
+                )
+                writer.add_scalar(
+                    "episode/cone_time",
+                    info.get("cone_calc_time", float("nan")),
+                    episode_counter,
+                )
                 rb = info.get("reward_breakdown", {})
                 for k, v in rb.items():
                     scalar_reward = float(v)
@@ -814,6 +829,11 @@ def train(
                             float(inf.get("pursuer_pitch_delta", float("nan"))),
                             episode_counter + i,
                         )
+                        writer.add_scalar(
+                            "episode/cone_time",
+                            float(inf.get("cone_calc_time", float("nan"))),
+                            episode_counter + i,
+                        )
                 rb_sum = defaultdict(float)
                 n_info = 0
                 min_list = []
@@ -824,6 +844,7 @@ def train(
                 pitch_list = []
                 yaw_diff_list = []
                 pitch_diff_list = []
+                cone_time_list = []
                 for inf in infos:
                     if inf:
                         n_info += 1
@@ -859,6 +880,8 @@ def train(
                             yaw_diff_list.append(inf["pursuer_yaw_diff"])
                         if "pursuer_pitch_diff" in inf:
                             pitch_diff_list.append(inf["pursuer_pitch_diff"])
+                        if "cone_calc_time" in inf:
+                            cone_time_list.append(inf["cone_calc_time"])
                 if n_info:
                     for k, v in rb_sum.items():
                         avg = v / n_info
@@ -892,6 +915,9 @@ def train(
                     if pitch_diff_list:
                         writer.add_scalar("train/pitch_diff", float(np.mean(pitch_diff_list)), episode)
                         writer.add_scalar("batch/pitch_diff", float(np.mean(pitch_diff_list)), episode)
+                    if cone_time_list:
+                        writer.add_scalar("train/cone_time", float(np.mean(cone_time_list)), episode)
+                        writer.add_scalar("batch/cone_time", float(np.mean(cone_time_list)), episode)
                     if min_list and start_list:
                         ratios = [m / s for m, s in zip(min_list, start_list) if s > 0]
                         if ratios:


### PR DESCRIPTION
## Summary
- measure capture cone reward time in `PursuitEvasionEnv`
- report `cone_calc_time` per episode via training logs
- document new metric in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer_ppo.py`

------
https://chatgpt.com/codex/tasks/task_e_6876a5afd73483328ef8f4bc53aea8d3