### PR TITLE
Remove angle reward, update heading reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will show episode rewards, evaluation results and losses during training.
 When a log directory is set, periodic checkpoints created with
 ``--checkpoint-every`` are stored under ``<log-dir>/checkpoints``.
 The logs also record a breakdown of the pursuer reward into shaping,
-closer, angle, heading, align and terminal components as well as the fractions of each
+closer, heading, align and terminal components as well as the fractions of each
 termination type aggregated over ``training.outcome_window`` episodes.
 When running multiple environments in parallel the average minimum
 distance to the evader and mean episode length are logged under
@@ -276,7 +276,7 @@ interval.
 Both `pursuit_evasion.py` and `train_pursuer_ppo.py` load the configuration
 at runtime, so changes take effect the next time you run the script.
 The reward shaping parameters `shaping_weight`, `closer_weight`,
-`angle_weight`, `heading_weight` and `align_weight` can be adjusted
+`heading_weight` and `align_weight` can be adjusted
 here as well to encourage desired
 behaviour. The `separation_cutoff_factor` option defines a multiplier of
 the initial pursuer--evader distance that ends the episode when the

--- a/env.yaml
+++ b/env.yaml
@@ -12,9 +12,7 @@ target_reward_distance: 100.0
 shaping_weight: 0.5
 # Additional reward weight for simply getting closer to the evader each step
 closer_weight: 1
-# Additional reward weight for reducing the pursuer-to-evader angle
-angle_weight: 1
-# Additional reward weight for aligning the pursuer and evader headings
+# Reward weight for aligning the pursuer and evader headings
 heading_weight: 1
 # Reward weight for pointing the pursuer directly at the evader
 align_weight: 0.05

--- a/plot_config.py
+++ b/plot_config.py
@@ -179,7 +179,7 @@ def main():
         f"time step: {cfg['time_step']} s\n"
         f"episode duration: {cfg.get('episode_duration', 0.0)} min\n"
         f"shaping weight: {cfg['shaping_weight']}\n"
-        f"angle weight: {cfg.get('angle_weight', 0.0)}\n"
+        f"heading weight: {cfg.get('heading_weight', 0.0)}\n"
     )
     fig.text(0.01, 0.95, evader_txt, fontsize=9, va="top")
     fig.text(0.25, 0.95, pursuer_txt, fontsize=9, va="top")

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -183,11 +183,7 @@ class PursuitEvasionEnv(gym.Env):
         # evader between consecutive steps. This complements the basic shaping
         # reward above which encourages closing the gap proportionally.
         self.closer_weight = self.cfg.get('closer_weight', 0.0)
-        # Reward for reducing the angle between the pursuer's force direction
-        # and the line of sight to the evader from one step to the next.
-        self.angle_weight = self.cfg.get('angle_weight', 0.0)
-        # Reward for reducing the difference between the pursuer and
-        # evader headings from one step to the next.
+        # Reward for aligning the pursuer and evader headings.
         self.heading_weight = self.cfg.get('heading_weight', 0.0)
         # Bonus for directly pointing the pursuer toward the evader.
         self.align_weight = self.cfg.get('align_weight', 0.0)
@@ -301,12 +297,9 @@ class PursuitEvasionEnv(gym.Env):
         )
         # record baseline distances for shaping rewards
         self.prev_pe_dist = np.linalg.norm(self.evader_pos - self.pursuer_pos)
-        vec_pe = self.evader_pos - self.pursuer_pos
-        self.prev_pe_angle = self._angle_between(self.pursuer_force_dir, vec_pe)
         # heading difference between the agents for shaping
         h_e = self.evader_vel / (np.linalg.norm(self.evader_vel) + 1e-8)
         h_p = self.pursuer_vel / (np.linalg.norm(self.pursuer_vel) + 1e-8)
-        self.prev_heading_angle = self._angle_between(h_p, h_e)
         # store the starting distance for logging
         self.start_pe_dist = self.prev_pe_dist
         target = np.array(self.cfg['target_position'], dtype=np.float32)
@@ -316,7 +309,6 @@ class PursuitEvasionEnv(gym.Env):
             'terminal': 0.0,
             'shaping': 0.0,
             'closer': 0.0,
-            'angle': 0.0,
             'heading': 0.0,
             'align': 0.0,
             'time': 0.0,
@@ -377,24 +369,10 @@ class PursuitEvasionEnv(gym.Env):
         closer_bonus = 0.0
         if self.closer_weight > 0.0 and dist_pe < self.prev_pe_dist:
             closer_bonus = self.closer_weight * (self.prev_pe_dist - dist_pe)
-        # Reward when the pursuer aligns its force direction with the line of
-        # sight to the evader compared to the previous step.
-        vec_pe = self.evader_pos - self.pursuer_pos
-        angle = self._angle_between(self.pursuer_force_dir, vec_pe)
-        angle_bonus = 0.0
-        if self.angle_weight > 0.0 and angle < self.prev_pe_angle:
-            angle_bonus = self.angle_weight * (self.prev_pe_angle - angle)
-        self.prev_pe_angle = angle
         # Reward for aligning the pursuer and evader headings
         h_e = self.evader_vel / (np.linalg.norm(self.evader_vel) + 1e-8)
         h_p = self.pursuer_vel / (np.linalg.norm(self.pursuer_vel) + 1e-8)
-        head_ang = self._angle_between(h_p, h_e)
-        heading_bonus = 0.0
-        if self.heading_weight > 0.0 and head_ang < self.prev_heading_angle:
-            heading_bonus = self.heading_weight * (
-                self.prev_heading_angle - head_ang
-            )
-        self.prev_heading_angle = head_ang
+        heading_bonus = self.heading_weight * float(np.dot(h_p, h_e))
         # Bonus for pointing the pursuer's velocity toward the evader
         p_u = self.pursuer_vel / (np.linalg.norm(self.pursuer_vel) + 1e-8)
         los = self.evader_pos - self.pursuer_pos
@@ -411,7 +389,6 @@ class PursuitEvasionEnv(gym.Env):
             r_p_terminal
             + shaping_reward
             + closer_bonus
-            + angle_bonus
             + heading_bonus
             + align_bonus
             - 0.001
@@ -419,7 +396,6 @@ class PursuitEvasionEnv(gym.Env):
         self._reward_breakdown['terminal'] += r_p_terminal
         self._reward_breakdown['shaping'] += shaping_reward
         self._reward_breakdown['closer'] += closer_bonus
-        self._reward_breakdown['angle'] += angle_bonus
         self._reward_breakdown['heading'] += heading_bonus
         self._reward_breakdown['align'] += align_bonus
         self._reward_breakdown['time'] += -0.001


### PR DESCRIPTION
## Summary
- remove angle reward from PursuitEvasion
- compute heading reward using cosine similarity
- drop `angle_weight` from env.yaml and docs
- show heading weight in plot config

## Testing
- `python -m py_compile pursuit_evasion.py`
- `python -m py_compile plot_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6876d1667274833293df476b95a3f96e