### PR TITLE
Add penalty for pursuer separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ closest pursuer--evader distance, number of steps and outcome. The outcome can
 be ``capture`` (pursuer success), ``evader_success`` (reaches the target in the
 air), ``evader_ground`` or ``pursuer_ground`` when a crash occurs,
 ``separation_exceeded`` if the starting distance has grown beyond the
-``separation_cutoff_factor`` multiple, or ``timeout`` when the step limit is
+``separation_cutoff_factor`` multiple (incurring ``separation_penalty``), or ``timeout`` when the step limit is
 reached. A capture is also triggered when the pursuer crosses through the
 evader's capture sphere between steps, detected by intersecting the line
 segment between consecutive pursuer positions with a radius of
@@ -280,7 +280,8 @@ The reward shaping parameters `shaping_weight`, `closer_weight`,
 here as well to encourage desired
 behaviour. The `separation_cutoff_factor` option defines a multiplier of
 the initial pursuer--evader distance that ends the episode when the
-agents drift farther apart than this threshold.
+agents drift farther apart than this threshold. When this occurs the
+pursuer receives `separation_penalty` as a terminal reward.
 The `capture_bonus` setting adds a time incentive for the pursuer by
 increasing its terminal reward when a capture occurs earlier. The final
 reward becomes `1 + capture_bonus * (max_steps - episode_steps)` where

--- a/env.yaml
+++ b/env.yaml
@@ -57,3 +57,7 @@ measurement_error_pct: 0.0
 # multiple.
 separation_cutoff_factor: 5.0
 
+# Penalty applied to the pursuer when the separation exceeds
+# ``separation_cutoff_factor`` times the starting distance
+separation_penalty: -1.0
+

--- a/pursuit_evasion.py
+++ b/pursuit_evasion.py
@@ -194,6 +194,8 @@ class PursuitEvasionEnv(gym.Env):
         self.meas_err = self.cfg.get('measurement_error_pct', 0.0) / 100.0
         # maximum allowed separation before the episode ends
         self.cutoff_factor = self.cfg.get('separation_cutoff_factor', 2.0)
+        # penalty when the pursuer falls behind and exceeds ``cutoff_factor``
+        self.separation_penalty = self.cfg.get('separation_penalty', -1.0)
         # Convert stall angles provided in degrees to radians once
         self.cfg['evader']['stall_angle'] = np.deg2rad(
             self.cfg['evader']['stall_angle']
@@ -630,7 +632,8 @@ class PursuitEvasionEnv(gym.Env):
         if dist_target_xy <= success_thresh and self.evader_pos[2] > 0.0:
             return True, 1.0, 0.0, 'evader_success'
         if dist >= self.cutoff_factor * self.start_pe_dist:
-            return True, 0.0, 0.0, 'separation_exceeded'
+            penalty = self.separation_penalty
+            return True, 0.0, penalty, 'separation_exceeded'
 
         # episode ends if either agent goes below ground level
         if self.pursuer_pos[2] < 0.0:


### PR DESCRIPTION
## Summary
- add `separation_penalty` option in env config
- penalize pursuer when separation threshold is exceeded
- document range penalty in README

## Testing
- `pip install -q pyyaml gymnasium torch numpy matplotlib tensorboard`
- `python - <<'PY'
from pursuit_evasion import PursuitEvasionEnv, load_config
cfg=load_config(); cfg['separation_cutoff_factor']=0.5; cfg['separation_penalty']=-1.0
env=PursuitEvasionEnv(cfg)
obs,_=env.reset()
for _ in range(1000):
    action={'pursuer': [0,0,0],'evader': env.action_space['evader'].sample()}
    _,r,done,_,info=env.step(action)
    if done:
        print(info.get('outcome'), r['pursuer'])
        break
PY


------
https://chatgpt.com/codex/tasks/task_e_6876d30350008332a0fe542b428045ae