### PR TITLE
Add GPU acceleration to env

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository contains a very small demonstration of a 3D pursuit--evasion
 environment written using `gymnasium`. Two agents (an evader and a pursuer)
 move in a simplified physics world. The provided script trains a pursuer policy
-using Proximal Policy Optimization (PPO).
+using Proximal Policy Optimization (PPO).  All vector calculations inside the
+environment now run on the GPU when one is available for faster simulation.
 
 ## Environment setup
 

--- a/train_pursuer_ppo.py
+++ b/train_pursuer_ppo.py
@@ -28,23 +28,27 @@ TABLE_HEADER = "{:>5} | {:>26} | {:>26} | {:>26} | {:>26} | {:>18} | {:>18} | {:
 
 
 def _format_row(step: int, env: PursuitEvasionEnv) -> str:
-    target_pos = np.asarray(env.cfg["target_position"], dtype=float)
+    """Return a formatted row summarising the current simulation state."""
+
+    target_pos = torch.tensor(
+        env.cfg["target_position"], device=env.device, dtype=torch.float32
+    )
     pe_vec = env.evader_pos - env.pursuer_pos
     et_vec = target_pos - env.evader_pos
     pv = env.pursuer_vel
     ev = env.evader_vel
-    pv_u = pv / (np.linalg.norm(pv) + 1e-8)
-    ev_u = ev / (np.linalg.norm(ev) + 1e-8)
-    pe_u = pe_vec / (np.linalg.norm(pe_vec) + 1e-8)
+    pv_u = pv / (torch.norm(pv) + 1e-8)
+    ev_u = ev / (torch.norm(ev) + 1e-8)
+    pe_u = pe_vec / (torch.norm(pe_vec) + 1e-8)
     return (
         f"{step:5d} | "
-        f"[{pe_vec[0]:7.1f} {pe_vec[1]:7.1f} {pe_vec[2]:7.1f}] | "
-        f"[{et_vec[0]:7.1f} {et_vec[1]:7.1f} {et_vec[2]:7.1f}] | "
-        f"[{pv[0]:7.1f} {pv[1]:7.1f} {pv[2]:7.1f}] | "
-        f"[{ev[0]:7.1f} {ev[1]:7.1f} {ev[2]:7.1f}] | "
-        f"[{pv_u[0]:6.2f} {pv_u[1]:6.2f} {pv_u[2]:6.2f}] | "
-        f"[{ev_u[0]:6.2f} {ev_u[1]:6.2f} {ev_u[2]:6.2f}] | "
-        f"[{pe_u[0]:6.2f} {pe_u[1]:6.2f} {pe_u[2]:6.2f}]"
+        f"[{pe_vec[0].item():7.1f} {pe_vec[1].item():7.1f} {pe_vec[2].item():7.1f}] | "
+        f"[{et_vec[0].item():7.1f} {et_vec[1].item():7.1f} {et_vec[2].item():7.1f}] | "
+        f"[{pv[0].item():7.1f} {pv[1].item():7.1f} {pv[2].item():7.1f}] | "
+        f"[{ev[0].item():7.1f} {ev[1].item():7.1f} {ev[2].item():7.1f}] | "
+        f"[{pv_u[0].item():6.2f} {pv_u[1].item():6.2f} {pv_u[2].item():6.2f}] | "
+        f"[{ev_u[0].item():6.2f} {ev_u[1].item():6.2f} {ev_u[2].item():6.2f}] | "
+        f"[{pe_u[0].item():6.2f} {pe_u[1].item():6.2f} {pe_u[2].item():6.2f}]"
     )
 
 from pursuit_evasion import (
@@ -86,34 +90,36 @@ def _format_step(env: PursuerOnlyEnv, step: int, target: np.ndarray) -> str:
     """Return formatted row for the table shown in ``play.py``."""
 
     pe_vec = env.env.evader_pos - env.env.pursuer_pos
-    et_vec = target - env.env.evader_pos
+    et_vec = torch.tensor(target, device=env.env.device, dtype=torch.float32) - env.env.evader_pos
     pv = env.env.pursuer_vel
     ev = env.env.evader_vel
-    pv_u = pv / (np.linalg.norm(pv) + 1e-8)
-    ev_u = ev / (np.linalg.norm(ev) + 1e-8)
-    pe_u = pe_vec / (np.linalg.norm(pe_vec) + 1e-8)
+    pv_u = pv / (torch.norm(pv) + 1e-8)
+    ev_u = ev / (torch.norm(ev) + 1e-8)
+    pe_u = pe_vec / (torch.norm(pe_vec) + 1e-8)
     return (
         f"{step:5d} | "
-        f"[{pe_vec[0]:7.1f} {pe_vec[1]:7.1f} {pe_vec[2]:7.1f}] | "
-        f"[{et_vec[0]:7.1f} {et_vec[1]:7.1f} {et_vec[2]:7.1f}] | "
-        f"[{pv[0]:7.1f} {pv[1]:7.1f} {pv[2]:7.1f}] | "
-        f"[{ev[0]:7.1f} {ev[1]:7.1f} {ev[2]:7.1f}] | "
-        f"[{pv_u[0]:6.2f} {pv_u[1]:6.2f} {pv_u[2]:6.2f}] | "
-        f"[{ev_u[0]:6.2f} {ev_u[1]:6.2f} {ev_u[2]:6.2f}] | "
-        f"[{pe_u[0]:6.2f} {pe_u[1]:6.2f} {pe_u[2]:6.2f}]"
+        f"[{pe_vec[0].item():7.1f} {pe_vec[1].item():7.1f} {pe_vec[2].item():7.1f}] | "
+        f"[{et_vec[0].item():7.1f} {et_vec[1].item():7.1f} {et_vec[2].item():7.1f}] | "
+        f"[{pv[0].item():7.1f} {pv[1].item():7.1f} {pv[2].item():7.1f}] | "
+        f"[{ev[0].item():7.1f} {ev[1].item():7.1f} {ev[2].item():7.1f}] | "
+        f"[{pv_u[0].item():6.2f} {pv_u[1].item():6.2f} {pv_u[2].item():6.2f}] | "
+        f"[{ev_u[0].item():6.2f} {ev_u[1].item():6.2f} {ev_u[2].item():6.2f}] | "
+        f"[{pe_u[0].item():6.2f} {pe_u[1].item():6.2f} {pe_u[2].item():6.2f}]"
     )
 
 
 def evader_policy(env: PursuitEvasionEnv) -> np.ndarray:
     """Evader accelerates toward the target with optional dive profile."""
     pos = env.evader_pos
-    target = np.array(env.cfg['target_position'], dtype=np.float32)
+    target = torch.tensor(
+        env.cfg['target_position'], device=env.device, dtype=torch.float32
+    )
     direction = target - pos
-    norm = np.linalg.norm(direction)
+    norm = torch.norm(direction)
     if norm > 1e-8:
         direction /= norm
-    theta = np.arctan2(direction[1], direction[0])
-    phi_target = np.arctan2(direction[2], np.linalg.norm(direction[:2]))
+    theta = torch.atan2(direction[1], direction[0]).item()
+    phi_target = torch.atan2(direction[2], torch.norm(direction[:2])).item()
     mode = env.cfg['evader'].get('trajectory', 'direct')
     if mode == 'dive':
         threshold = env.cfg['evader'].get('dive_angle', 0.0)
@@ -123,7 +129,11 @@ def evader_policy(env: PursuitEvasionEnv) -> np.ndarray:
             phi = phi_target
     else:
         phi = phi_target
-    phi = np.clip(phi, -env.cfg['evader']['stall_angle'], env.cfg['evader']['stall_angle'])
+    phi = np.clip(
+        phi,
+        -env.cfg['evader']['stall_angle'],
+        env.cfg['evader']['stall_angle'],
+    )
     mag = env.cfg['evader']['max_acceleration']
     return np.array([mag, theta, phi], dtype=np.float32)
 
@@ -168,9 +178,16 @@ class PursuerOnlyEnv(gym.Env):
             done = True
             info.setdefault('episode_steps', self.cur_step)
             info.setdefault('min_distance', float(self.env.min_pe_dist))
-            info.setdefault('final_distance', float(np.linalg.norm(self.env.evader_pos - self.env.pursuer_pos)))
-            target = np.array(self.env.cfg['target_position'], dtype=np.float32)
-            dist_target = np.linalg.norm(self.env.evader_pos - target)
+            info.setdefault(
+                'final_distance',
+                float(torch.norm(self.env.evader_pos - self.env.pursuer_pos))
+            )
+            target = torch.tensor(
+                self.env.cfg['target_position'],
+                dtype=torch.float32,
+                device=self.env.device,
+            )
+            dist_target = torch.norm(self.env.evader_pos - target)
             info.setdefault('evader_to_target', float(dist_target))
             info.setdefault('start_distance', float(self.env.start_pe_dist))
             info['outcome'] = 'timeout'
@@ -403,8 +420,8 @@ def train(
             collect_start = time.perf_counter()
         if num_envs == 1:
             obs, _ = env.reset()
-            init_pursuer_pos = env.env.pursuer_pos.copy()
-            init_evader_pos = env.env.evader_pos.copy()
+            init_pursuer_pos = env.env.pursuer_pos.clone()
+            init_evader_pos = env.env.evader_pos.clone()
             done = False
             log_probs = []
             values = []


### PR DESCRIPTION
## Summary
- use CUDA when available via global DEVICE constant
- port env vector maths to torch so physics steps run on GPU
- pass device into training helpers
- document GPU support in README

## Testing
- `python -m py_compile pursuit_evasion.py train_pursuer_ppo.py play.py`
- ❌ `python pursuit_evasion.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687848b9b16483329bfa139555588c24