### PR TITLE
Add detailed episode metrics to Q-learning logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ overriding the episode count and log directory. All defaults live in
 ``setup/training.yaml`` and can be modified directly in that file.
 
 Pass ``--log-dir`` to write TensorBoard metrics such as episode reward,
-evaluation return, loss and exploration rate.
+evaluation return, loss, exploration rate, minimum pursuer--evader distance,
+start-distance ratio and action deltas.
 
 ### Monitoring training with TensorBoard
 
 When ``--log-dir`` is supplied the trainer writes episode reward, loss,
-exploration rate and evaluation return for visualisation with TensorBoard:
+exploration rate, distance ratios, action deltas and evaluation statistics for
+visualisation with TensorBoard:
 
 ```bash
 tensorboard --logdir runs


### PR DESCRIPTION
## Summary
- log min distance, start-distance ratio, action deltas, orientation changes, reward breakdown and capture indicator during DQN training
- expose evaluation helper returning average min distance, capture rate and episode length
- document new TensorBoard metrics in README

## Testing
- `python -m py_compile train_pursuer_qlearning.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c839cf54e08332939de456a6f4fe4f