### PR TITLE
Log curriculum parameter ranges and batch success metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ overriding the episode count and log directory. All defaults live in
 
 Pass ``--log-dir`` to write TensorBoard metrics such as episode reward,
 evaluation return, loss, exploration rate, minimum pursuer--evader distance,
-start-distance ratio and action deltas.
+start-distance ratio, action deltas, the sliding success rate over the most
+recent training batch and the active curriculum parameter ranges.
 
 ### Monitoring training with TensorBoard
 
 When ``--log-dir`` is supplied the trainer writes episode reward, loss,
-exploration rate, distance ratios, action deltas and evaluation statistics for
+exploration rate, distance ratios, action deltas, active spawn ranges and the
+success rate computed over the last ``q_learning.batch_size`` episodes for
 visualisation with TensorBoard:
 
 ```bash


### PR DESCRIPTION
## Summary
- add helpers that extract curriculum parameter ranges from the active environment config and log them to TensorBoard during training and evaluation
- record a sliding success rate computed over the most recent training batch to improve feedback on capture frequency
- document the new TensorBoard metrics in the README

## Testing
- python -m compileall train_pursuer_qlearning.py

------
https://chatgpt.com/codex/tasks/task_e_68c83e5195848332a8519bcdfbd7979d