### PR TITLE
Derive discrete pursuer actions from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ The ``train_pursuer_qlearning.py`` script implements deep Q-learning with a
 replay buffer and target network. Continuous observations feed a small MLP
 which outputs action-values for the discrete manoeuvre set.
 
+The manoeuvres themselves are derived from ``setup/env.yaml`` at runtime via
+``build_action_set``. The helper scales acceleration, yaw and pitch commands by
+``time_step`` and the pursuer's maximum rates so that discrete actions remain
+valid when either quantity changes.
+
 Run training with:
 
 ```bash


### PR DESCRIPTION
## Summary
- derive the discrete pursuer action table from the environment configuration via `build_action_set`
- use the computed action table throughout training, evaluation, and the play utility to keep manoeuvres valid for the current timestep
- document the dynamic action set behaviour in the README

## Testing
- python -m compileall train_pursuer_qlearning.py play.py

------
https://chatgpt.com/codex/tasks/task_e_68c89373ac3c83328feb203e77f45691