### PR TITLE
Restore reward shaping telemetry and penalties

### DIFF
--- a/play.py
+++ b/play.py
@@ -211,6 +211,11 @@ def run_episode(
                 f"yaw_diff={yaw_diff:.2f}  "
                 f"pitch_diff={pitch_diff:.2f}"
             )
+        breakdown = info.get("reward_breakdown")
+        if breakdown:
+            print("Reward breakdown:")
+            for key in sorted(breakdown):
+                print(f"  {key:>24s}: {breakdown[key]:+.3f}")
 
     # Plot the trajectories in 3D
     if profile:

--- a/plot_config.py
+++ b/plot_config.py
@@ -179,6 +179,10 @@ def main():
         f"time step: {cfg['time_step']} s\n"
         f"episode duration: {cfg.get('episode_duration', 0.0)} min\n"
         f"shaping weight: {cfg['shaping_weight']}\n"
+        f"align weight: {cfg.get('align_weight', 0.0)}\n"
+        f"heading weight: {cfg.get('heading_weight', 0.0)}\n"
+        f"closer weight: {cfg.get('closer_weight', 0.0)}\n"
+        f"time penalty: {cfg.get('time_penalty', 0.0)}\n"
     )
     fig.text(0.01, 0.95, evader_txt, fontsize=9, va="top")
     fig.text(0.25, 0.95, pursuer_txt, fontsize=9, va="top")

--- a/setup/env.yaml
+++ b/setup/env.yaml
@@ -12,6 +12,12 @@ target_reward_distance: 100.0
 shaping_weight: 0.002
 # Reward weight for pointing the pursuer directly at the evader
 align_weight: 0.05
+# Reward weight for keeping the pursuer velocity aligned with the evader
+heading_weight: 0.02
+# Reward weight for decreasing pursuer--evader separation between steps
+closer_weight: 0.02
+# Constant time penalty applied to the pursuer each step
+time_penalty: 0.001
 # Extra reward multiplier for capturing before the time limit. The pursuer
 # receives ``1 + capture_bonus * (max_steps - episode_steps)`` when a capture
 # occurs, allowing earlier interceptions to yield higher returns.


### PR DESCRIPTION
## Summary
- reinstate per-component reward accounting in the environment, including cosine-based heading shaping, configurable time penalties, and explicit capture/separation/ground tracking
- surface the reward breakdown and running minimum-distance statistics throughout training/evaluation logs and the play utility while updating configuration defaults for heading/closer shaping
- document the expanded telemetry in the README and configuration visualisation

## Testing
- python -m compileall pursuit_evasion.py train_pursuer_qlearning.py play.py plot_config.py

------
https://chatgpt.com/codex/tasks/task_e_68c918508c4c833283f22125893e0c71