### PR TITLE
Fix pursuer relative turn commands in DQN trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ The manoeuvres themselves are derived from ``setup/env.yaml`` at runtime via
 ``time_step`` and the pursuer's maximum rates so that discrete actions remain
 valid when either quantity changes.
 
+During execution the trainer interprets the discrete yaw/pitch entries as
+relative turns and offsets them by the pursuer's current heading before calling
+``env.step``. This mirrors the environment's internal update logic, which moves
+the force vector toward absolute yaw/pitch targets, and ensures each discrete
+action yields a consistent incremental turn regardless of the pursuer's current
+orientation.
+
 Run training with:
 
 ```bash


### PR DESCRIPTION
## Summary
- add helpers that translate the pursuer's current force direction into yaw/pitch angles so discrete actions remain relative turns
- update training and evaluation loops to convert tabled yaw/pitch deltas into absolute commands before stepping the environment
- document the relative-command handling in the README for clarity

## Testing
- python -m compileall train_pursuer_qlearning.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e22a952083328d95e14640502090